### PR TITLE
读取ftp文件时, path参数支持正则表达式来匹配文件

### DIFF
--- a/flinkx-ftp/flinkx-ftp-core/src/main/java/com/dtstack/flinkx/ftp/IFtpHandler.java
+++ b/flinkx-ftp/flinkx-ftp-core/src/main/java/com/dtstack/flinkx/ftp/IFtpHandler.java
@@ -122,4 +122,28 @@ public interface IFtpHandler {
      * @throws IOException 文件句柄操作异常
      */
     void completePendingCommand() throws IOException;
+
+    /**
+     * 递归获取指定路线下的所有目录和文件
+     * @param superPath  指定路径
+     * @param directoryList 路径下的目录列表
+     * @param fileList   路径下的文件列表
+     */
+    default void getFileRecursiveList(String superPath, List<String> directoryList, List<String > fileList){
+
+        try {
+            List<String> filePathLis = getFiles(superPath);
+            for (String filePath:  filePathLis  ) {
+                if (isDirExist(filePath) ==true){
+                    directoryList.add(filePath);
+                    getFileRecursiveList(filePath,directoryList,fileList);
+                }else {
+                    fileList.add(filePath);
+                }
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
 }


### PR DESCRIPTION
1.读取ftp文件时,path参数支持正则表达式来匹配文件
2.如果匹配到文件,则添加该文件.
3.如果匹配到目录,则添加该目录下的所有文件.
4.支持多个 正则表达式, 不同表达式之间用逗号分隔
5.路径中不能包含逗号.
e.g
"path": ".*iotxqb.*",

Signed-off-by: chenfan <930382646@qq.com>