### PR TITLE
fix: UnsupportedType BIGINT UNSIGNED and more 修改不支持BIGINT UNSIGNED等

### DIFF
--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/converter/JdbcColumnConverter.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/converter/JdbcColumnConverter.java
@@ -41,6 +41,7 @@ import io.vertx.core.json.JsonArray;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.Time;
@@ -90,6 +91,11 @@ public class JdbcColumnConverter
             AbstractBaseColumn baseColumn = null;
             if (StringUtils.isBlank(fieldConf.getValue())) {
                 Object field = resultSet.getObject(converterIndex + 1);
+                // 目前仅有 BIGINT UNSIGNED 类型会被解析成 java.math.BigInteger类型, 因此默认将BigInteger转化java.lang.Long
+                // 来源请参考: https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html
+                if (field instanceof java.math.BigInteger) {
+                    field = ((BigInteger) field).longValue();
+                }
                 baseColumn =
                         (AbstractBaseColumn)
                                 toInternalConverters[converterIndex].deserialize(field);

--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
@@ -273,7 +273,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
     @Override
     public FormatState getFormatState() {
         super.getFormatState();
-        formatState.setState(state);
+        if (formatState != null) formatState.setState(state);
         return formatState;
     }
 

--- a/flinkx-connectors/flinkx-connector-mysql/src/main/java/com/dtstack/flinkx/connector/mysql/converter/MysqlRawTypeConverter.java
+++ b/flinkx-connectors/flinkx-connector-mysql/src/main/java/com/dtstack/flinkx/connector/mysql/converter/MysqlRawTypeConverter.java
@@ -25,12 +25,17 @@ public class MysqlRawTypeConverter {
                 return DataTypes.BOOLEAN();
             case "TINYINT":
                 return DataTypes.TINYINT();
+            case "SMALLINT UNSIGNED": // 以下两种带有UNSIGNED标记的默认都使用 IntType,底层是java.lang.Integer 类型
+            case "MEDIUMINT UNSIGNED":
             case "SMALLINT":
             case "MEDIUMINT":
             case "INT":
             case "INTEGER":
             case "INT24":
                 return DataTypes.INT();
+            case "INT UNSIGNED":  // 以下三种带有UNSIGNED标记的默认都使用 BigIntType,底层是java.lang.Long类型
+            case "INTEGER UNSIGNED":
+            case "BIGINT UNSIGNED":
             case "BIGINT":
                 return DataTypes.BIGINT();
             case "REAL":


### PR DESCRIPTION
1、对mysql增加了 SMALLINT、MEDIUMINT、INT、INTEGER、BIGINT 几种类型在标记 UNSIGNED 时的解析支持.
2、针对 BIGINT UNSIGNED 默认解析成java.lang.Long 类型。原jdbc会解析成 java.math.BigInteger 类型。 
3、参考资料: https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-type-conversions.html