### PR TITLE
[fix][connectors redis]redis sink values保留字段类型方便反序列化

### DIFF
--- a/flinkx-connectors/flinkx-connector-redis/src/main/java/com/dtstack/flinkx/connector/redis/converter/RedisColumnConverter.java
+++ b/flinkx-connectors/flinkx-connector-redis/src/main/java/com/dtstack/flinkx/connector/redis/converter/RedisColumnConverter.java
@@ -18,6 +18,7 @@
 
 package com.dtstack.flinkx.connector.redis.converter;
 
+import com.dtstack.flinkx.conf.FieldConf;
 import com.dtstack.flinkx.connector.redis.conf.RedisConf;
 import com.dtstack.flinkx.connector.redis.enums.RedisDataMode;
 import com.dtstack.flinkx.connector.redis.enums.RedisDataType;
@@ -25,6 +26,7 @@ import com.dtstack.flinkx.converter.AbstractRowConverter;
 import com.dtstack.flinkx.element.ColumnRowData;
 import com.dtstack.flinkx.element.column.StringColumn;
 import com.dtstack.flinkx.element.column.TimestampColumn;
+import com.dtstack.flinkx.util.JsonUtil;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -34,7 +36,10 @@ import redis.clients.jedis.Jedis;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static com.dtstack.flinkx.connector.redis.options.RedisOptions.REDIS_CRITICAL_TIME;
 import static com.dtstack.flinkx.connector.redis.options.RedisOptions.REDIS_KEY_VALUE_SIZE;
@@ -141,7 +146,17 @@ public class RedisColumnConverter extends AbstractRowConverter<Object, Object, J
     }
 
     private String concatValues(ColumnRowData row) {
-        return StringUtils.join(getValues(row), redisConf.getValueFieldDelimiter());
+        List<FieldConf> columns = redisConf.getColumn();
+        Map<String, Object> fieldMap = new HashMap<>();
+        int index = 0;
+
+        for (FieldConf fieldConf : columns) {
+            if (Objects.nonNull(row.getField(index))) {
+                fieldMap.put(fieldConf.getName(), row.getField(index).getData());
+            }
+            index++;
+        }
+        return JsonUtil.toJson(fieldMap);
     }
 
     private String concatKey(ColumnRowData row) {


### PR DESCRIPTION
当写入sink的数据类型为string时，value为源数据的value值组成的数组根据分隔符去组成一个新的字符串，并且不能看到key和value的对应关系，拿到sink数据后，也不能根据反序列化获得对应的对象。修改后，存入的数据是根据key和value一一对应组成map并转成json格式的string，拿出sink数据后，能够根据反序列化获得对应的对象。