### PR TITLE
fix[#622] jdbc connection in exact_once mode forget commit transaction.

### DIFF
--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/sink/JdbcOutputFormat.java
@@ -217,6 +217,7 @@ public class JdbcOutputFormat extends BaseRichOutputFormat {
             // 开启了cp，但是并没有使用2pc方式让下游数据可见
             if (Semantic.EXACTLY_ONCE == semantic) {
                 rowsOfCurrentTransaction += rows.size();
+                JdbcUtil.commit(dbConn);
             }
         } catch (Exception e) {
             LOG.warn(


### PR DESCRIPTION
jdbc connection in exact_once mode forget commit transaction.