### PR TITLE
fix[#764] Duplicate data occurred when use jdbc polling Data

### DIFF
--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/sink/JdbcOutputFormat.java
@@ -217,6 +217,7 @@ public class JdbcOutputFormat extends BaseRichOutputFormat {
             // 开启了cp，但是并没有使用2pc方式让下游数据可见
             if (Semantic.EXACTLY_ONCE == semantic) {
                 rowsOfCurrentTransaction += rows.size();
+                JdbcUtil.commit(dbConn);
             }
         } catch (Exception e) {
             LOG.warn(

--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/sink/JdbcOutputFormat.java
@@ -217,7 +217,6 @@ public class JdbcOutputFormat extends BaseRichOutputFormat {
             // 开启了cp，但是并没有使用2pc方式让下游数据可见
             if (Semantic.EXACTLY_ONCE == semantic) {
                 rowsOfCurrentTransaction += rows.size();
-                JdbcUtil.commit(dbConn);
             }
         } catch (Exception e) {
             LOG.warn(

--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
@@ -809,7 +809,16 @@ public class JdbcInputFormat extends BaseRichInputFormat {
      * @throws SQLException
      */
     protected void queryStartLocation() throws SQLException {
-        ps = dbConn.prepareStatement(jdbcConf.getQuerySql(), resultSetType, resultSetConcurrency);
+        // 在首次查询时需要增加一下，排序
+        StringBuilder updateSqlBuilder = new StringBuilder(128);
+        updateSqlBuilder.append(jdbcConf.getQuerySql());
+        updateSqlBuilder
+                .append(" ORDER BY ")
+                .append(jdbcDialect.quoteIdentifier(jdbcConf.getIncreColumn()))
+                .append(" ASC");
+        ps =
+                dbConn.prepareStatement(
+                        updateSqlBuilder.toString(), resultSetType, resultSetConcurrency);
         ps.setFetchSize(jdbcConf.getFetchSize());
         ps.setQueryTimeout(jdbcConf.getQueryTimeOut());
         resultSet = ps.executeQuery();


### PR DESCRIPTION
修复问题：JDBC数据源在实时扫表拉取数据时，在数据量大于1万条时，会出现部分数据重复，后续在增加数据，便不会出现重复。
原因：在实时抽取数据过程中，第一次从JDBC数据源的SQL，没有按照splitKey进行排序，导致获取的下一次的起始位置数据不是上一次轮询后的最大值，导致数据重复。
修复方式：在扫表时对更新SQL，增加order by，避免该问题的发生
根据反馈：将代码合并到Master分支