### PR TITLE
fix[#764] Duplicate data occurred when use jdbc polling

### DIFF
--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
@@ -809,7 +809,16 @@ public class JdbcInputFormat extends BaseRichInputFormat {
      * @throws SQLException
      */
     protected void queryStartLocation() throws SQLException {
-        ps = dbConn.prepareStatement(jdbcConf.getQuerySql(), resultSetType, resultSetConcurrency);
+        // 在首次查询时需要增加一下，排序
+        StringBuilder updateSqlBuilder = new StringBuilder(128);
+        updateSqlBuilder.append(jdbcConf.getQuerySql());
+        updateSqlBuilder
+                .append(" ORDER BY ")
+                .append(jdbcDialect.quoteIdentifier(jdbcConf.getIncreColumn()))
+                .append(" ASC");
+        ps =
+                dbConn.prepareStatement(
+                        updateSqlBuilder.toString(), resultSetType, resultSetConcurrency);
         ps.setFetchSize(jdbcConf.getFetchSize());
         ps.setQueryTimeout(jdbcConf.getQueryTimeOut());
         resultSet = ps.executeQuery();

--- a/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
+++ b/flinkx-connectors/flinkx-connector-jdbc-base/src/main/java/com/dtstack/flinkx/connector/jdbc/source/JdbcInputFormat.java
@@ -809,7 +809,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
      * @throws SQLException
      */
     protected void queryStartLocation() throws SQLException {
-        // 在首次查询时需要增加一下，排序
+        // add order by to query SQL avoid duplicate data
         StringBuilder updateSqlBuilder = new StringBuilder(128);
         updateSqlBuilder.append(jdbcConf.getQuerySql());
         updateSqlBuilder


### PR DESCRIPTION
problem: when the JDBC data source scans and pulls data in real time, when the amount of data is more than 10000, there will be some data duplication. If the data is added later, there will be no duplication.

Reason: in the process of real-time data extraction, the SQL from the JDBC data source for the first time is not sorted according to the splitkey, resulting in that the next starting position data obtained is not the maximum value after the last polling, resulting in data duplication.

Repair method: when scanning the table, update the SQL and add order by to avoid this problem

According to the feedback: merge the code into the 'master' branch from my 'master' branch