### PR TITLE
[fix#827][jdbc] jdbc PreparedStmtProxy can't resolve DELETE statement.this is make flink retraction failed.

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/sink/DynamicPreparedStmt.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/sink/DynamicPreparedStmt.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.dtstack.chunjun.connector.jdbc.sink;
 
 import com.dtstack.chunjun.conf.FieldConf;
@@ -24,6 +25,7 @@ import com.dtstack.chunjun.connector.jdbc.statement.FieldNamedPreparedStatement;
 import com.dtstack.chunjun.connector.jdbc.statement.FieldNamedPreparedStatementImpl;
 import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
 import com.dtstack.chunjun.converter.AbstractRowConverter;
+import com.dtstack.chunjun.enums.EWriteMode;
 import com.dtstack.chunjun.util.TableUtil;
 
 import org.apache.flink.table.types.logical.RowType;
@@ -71,6 +73,7 @@ public class DynamicPreparedStmt {
             RowKind rowKind,
             Connection connection,
             JdbcDialect jdbcDialect,
+            JdbcConf jdbcConf,
             boolean writeExtInfo)
             throws SQLException {
         DynamicPreparedStmt dynamicPreparedStmt = new DynamicPreparedStmt();
@@ -81,7 +84,14 @@ public class DynamicPreparedStmt {
         dynamicPreparedStmt.getColumnMeta(schemaName, tableName, connection);
         dynamicPreparedStmt.buildRowConvert();
 
-        String sql = dynamicPreparedStmt.prepareTemplates(rowKind, schemaName, tableName);
+        String sql =
+                dynamicPreparedStmt.prepareTemplates(
+                        rowKind,
+                        schemaName,
+                        tableName,
+                        jdbcConf.getUniqueKey().toArray(new String[0]),
+                        jdbcConf.getMode(),
+                        jdbcConf.isAllReplace());
         String[] fieldNames = new String[dynamicPreparedStmt.columnNameList.size()];
         dynamicPreparedStmt.columnNameList.toArray(fieldNames);
         dynamicPreparedStmt.fieldNamedPreparedStatement =
@@ -95,12 +105,14 @@ public class DynamicPreparedStmt {
             RowKind rowKind,
             Connection connection,
             JdbcDialect jdbcDialect,
-            List<FieldConf> fieldConfList,
+            JdbcConf jdbcConf,
             AbstractRowConverter<?, ?, ?, ?> rowConverter)
             throws SQLException {
+        List<FieldConf> fieldConfList = jdbcConf.getColumn();
         DynamicPreparedStmt dynamicPreparedStmt = new DynamicPreparedStmt();
         dynamicPreparedStmt.jdbcDialect = jdbcDialect;
         dynamicPreparedStmt.rowConverter = rowConverter;
+        dynamicPreparedStmt.jdbcConf = jdbcConf;
         String[] fieldNames = new String[fieldConfList.size()];
         for (int i = 0; i < fieldConfList.size(); i++) {
             FieldConf fieldConf = fieldConfList.get(i);
@@ -108,7 +120,14 @@ public class DynamicPreparedStmt {
             dynamicPreparedStmt.columnNameList.add(fieldConf.getName());
             dynamicPreparedStmt.columnTypeList.add(fieldConf.getType());
         }
-        String sql = dynamicPreparedStmt.prepareTemplates(rowKind, schemaName, tableName);
+        String sql =
+                dynamicPreparedStmt.prepareTemplates(
+                        rowKind,
+                        schemaName,
+                        tableName,
+                        jdbcConf.getUniqueKey().toArray(new String[0]),
+                        jdbcConf.getMode(),
+                        jdbcConf.isAllReplace());
         dynamicPreparedStmt.fieldNamedPreparedStatement =
                 FieldNamedPreparedStatementImpl.prepareStatement(connection, sql, fieldNames);
         return dynamicPreparedStmt;
@@ -131,14 +150,20 @@ public class DynamicPreparedStmt {
         return dynamicPreparedStmt;
     }
 
-    protected String prepareTemplates(RowKind rowKind, String schemaName, String tableName) {
+    protected String prepareTemplates(
+            RowKind rowKind,
+            String schemaName,
+            String tableName,
+            String[] uniqueKeys,
+            String mode,
+            boolean allReplace) {
         String singleSql = null;
         switch (rowKind) {
             case INSERT:
             case UPDATE_AFTER:
                 singleSql =
-                        jdbcDialect.getInsertIntoStatement(
-                                schemaName, tableName, columnNameList.toArray(new String[0]));
+                        this.getInsertStatementWithWriteMode(
+                                mode, schemaName, tableName, uniqueKeys, allReplace);
                 break;
             case DELETE:
             case UPDATE_BEFORE:
@@ -149,6 +174,40 @@ public class DynamicPreparedStmt {
             default:
                 // TODO 异常如何处理
                 LOG.warn("not support RowKind: {}", rowKind);
+        }
+
+        return singleSql;
+    }
+
+    protected String getInsertStatementWithWriteMode(
+            String mode,
+            String schemaName,
+            String tableName,
+            String[] uniqueKeys,
+            boolean allReplace) {
+        String singleSql;
+        if (EWriteMode.INSERT.name().equalsIgnoreCase(mode)) {
+            singleSql =
+                    jdbcDialect.getInsertIntoStatement(
+                            schemaName, tableName, columnNameList.toArray(new String[0]));
+        } else if (EWriteMode.REPLACE.name().equalsIgnoreCase(mode)) {
+            singleSql =
+                    jdbcDialect
+                            .getReplaceStatement(
+                                    schemaName, tableName, columnNameList.toArray(new String[0]))
+                            .get();
+        } else if (EWriteMode.UPDATE.name().equalsIgnoreCase(mode)) {
+            singleSql =
+                    jdbcDialect
+                            .getUpsertStatement(
+                                    schemaName,
+                                    tableName,
+                                    columnNameList.toArray(new String[0]),
+                                    uniqueKeys,
+                                    allReplace)
+                            .get();
+        } else {
+            throw new IllegalArgumentException("Unknown write mode:" + mode);
         }
 
         return singleSql;

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/sink/PreparedStmtProxy.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/sink/PreparedStmtProxy.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.dtstack.chunjun.connector.jdbc.sink;
 
 import com.dtstack.chunjun.connector.jdbc.conf.JdbcConf;
@@ -69,7 +70,7 @@ public class PreparedStmtProxy implements FieldNamedPreparedStatement {
 
     private final int cacheDurationMin = 10;
 
-    /** LUR cache key info: database_table_rowkind * */
+    /** LRU cache key info: database_table_rowkind * */
     protected Cache<String, DynamicPreparedStmt> pstmtCache;
 
     /** 当前的执行sql的preparestatement */
@@ -158,6 +159,7 @@ public class PreparedStmtProxy implements FieldNamedPreparedStatement {
                                             columnRowData.getRowKind(),
                                             connection,
                                             jdbcDialect,
+                                            jdbcConf,
                                             writeExtInfo);
                                 } catch (SQLException e) {
                                     LOG.warn("", e);
@@ -169,7 +171,7 @@ public class PreparedStmtProxy implements FieldNamedPreparedStatement {
             currentRowConverter = fieldNamedPreparedStatement.getRowConverter();
         } else {
             String key =
-                    getPstmtCacheKey(jdbcConf.getSchema(), jdbcConf.getTable(), RowKind.INSERT);
+                    getPstmtCacheKey(jdbcConf.getSchema(), jdbcConf.getTable(), row.getRowKind());
             DynamicPreparedStmt fieldNamedPreparedStatement =
                     pstmtCache.get(
                             key,
@@ -181,7 +183,7 @@ public class PreparedStmtProxy implements FieldNamedPreparedStatement {
                                             row.getRowKind(),
                                             connection,
                                             jdbcDialect,
-                                            jdbcConf.getColumn(),
+                                            jdbcConf,
                                             currentRowConverter);
                                 } catch (SQLException e) {
                                     LOG.warn("", e);


### PR DESCRIPTION
mysql create ddl：
CREATE DATABASE `flinkx` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci */;

create table kuaidi
(
    kuaidi_name varchar(20),
    product_id  varchar(100)
);

create table result
(
    kuaidi_name varchar(20),
    count       int,
    primary key (kuaidi_name)
);

INSERT INTO flinkx.kuaidi (kuaidi_name, product_id) VALUES ('申通', '1');
INSERT INTO flinkx.kuaidi (kuaidi_name, product_id) VALUES ('顺丰', '2');
INSERT INTO flinkx.kuaidi (kuaidi_name, product_id) VALUES ('中通', '3');
INSERT INTO flinkx.kuaidi (kuaidi_name, product_id) VALUES ('中通', '1');

flinkx.sql:
CREATE TABLE kuaidi
(
  product_id string,
  kuaidi_name string
) WITH (
 'connector' = 'mysql-x',
  'url' = 'jdbc:mysql://localhost:3306/flinkx?useCursorFetch=true&fetchSize=1000&useUnicode=true&characterEncoding=UTF-8',
  'table-name' = 'kuaidi',
  'username' = 'root',
  'password' = '123456',
  'scan.parallelism' = '1'
  );

CREATE TABLE product (
     kuaidi_name string,
     `count` bigint,
    primary key (kuaidi_name) NOT ENFORCED
) WITH (
     'connector' = 'mysql-x',
      'url' = 'jdbc:mysql://localhost:3306/flinkx?useUnicode=true&characterEncoding=UTF-8',
      'table-name' = 'result',
      'username' = 'root',
      'password' = '123456',
     'sink.buffer-flush.max-rows' = '1', -- 批量写数据条数，默认：1024
     'sink.buffer-flush.interval' = '1000000', -- 批量写时间间隔，默认：10000毫秒
     'sink.all-replace' = 'true', -- 解释如下(其他rdb数据库类似)：默认：false。定义了PRIMARY KEY才有效，否则是追加语句
                               -- sink.all-replace = 'true' 生成如：INSERT INTO `result3`(`mid`, `mbb`, `sid`, `sbb`) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE `mid`=VALUES(`mid`), `mbb`=VALUES(`mbb`), `sid`=VALUES(`sid`), `sbb`=VALUES(`sbb`) 。会将所有的数据都替换。
                               -- sink.all-replace = 'false' 生成如：INSERT INTO `result3`(`mid`, `mbb`, `sid`, `sbb`) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE `mid`=IFNULL(VALUES(`mid`),`mid`), `mbb`=IFNULL(VALUES(`mbb`),`mbb`), `sid`=IFNULL(VALUES(`sid`),`sid`), `sbb`=IFNULL(VALUES(`sbb`),`sbb`) 。如果新值为null，数据库中的旧值不为null，则不会覆盖。
     'sink.parallelism' = '1'  -- 写入结果的并行度，默认：null
  );

INSERT into product
  select
  kuaidi_name,
  count(1) `count`
  from
  (select
  product_id,
  last_value(kuaidi_name) kuaidi_name
  from kuaidi
  group by product_id)
group by kuaidi_name;

error picture:
![image](https://user-images.githubusercontent.com/51357674/169026647-79d78db8-d914-4270-a60f-d20391d8764c.png)


correct picture:
![image](https://user-images.githubusercontent.com/51357674/169026402-7fc2a8ec-500c-421b-8fc4-345cb7d07e6e.png)


