### PR TITLE
读取ftp的时候，程序报错

### DIFF
--- a/flinkx-connectors/flinkx-connector-ftp/src/main/java/com/dtstack/flinkx/connector/ftp/source/FtpSourceFactory.java
+++ b/flinkx-connectors/flinkx-connector-ftp/src/main/java/com/dtstack/flinkx/connector/ftp/source/FtpSourceFactory.java
@@ -68,16 +68,7 @@ public class FtpSourceFactory extends SourceFactory {
     public DataStream<RowData> createSource() {
         FtpInputFormatBuilder builder = new FtpInputFormatBuilder();
         builder.setFtpConfig(ftpConfig);
-        List<FieldConf> fieldConfList =
-                ftpConfig.getColumn().stream()
-                        .peek(
-                                fieldConf -> {
-                                    if (fieldConf.getName() == null) {
-                                        fieldConf.setName(String.valueOf(fieldConf.getIndex()));
-                                    }
-                                })
-                        .collect(Collectors.toList());
-        ftpConfig.setColumn(fieldConfList);
+        ftpConfig.setColumn(syncConf.getReader().getFieldList());
         final RowType rowType =
                 TableUtil.createRowType(ftpConfig.getColumn(), getRawTypeConverter());
         builder.setRowConverter(new FtpColumnConverter(rowType, ftpConfig));


### PR DESCRIPTION
读取ftp数据的时候，FtpSourceFactory#createSource，ftpConfig.setColumn 每个FieldConf的index为null，会导致FtpInputFormat#nextRecordInternal 里的分支永远不会执行，见issue 837