### PR TITLE
[hotfix-866][jdbc]  password 为空导致的认证失败

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/lookup/provider/DruidDataSourceProvider.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/lookup/provider/DruidDataSourceProvider.java
@@ -44,7 +44,8 @@ public class DruidDataSourceProvider implements DataSourceProvider {
             String key = entry.getKey();
             if (!"provider_class".equals(key)) {
                 String formattedName = CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, key);
-                props.setProperty(formattedName, entry.getValue().toString());
+                props.setProperty(
+                        formattedName, entry.getValue() == null ? "" : entry.getValue().toString());
             }
         }
         dataSource.configFromPropety(props);


### PR DESCRIPTION
#866  password 为空导致的认证失败