### PR TITLE
[feat-755]Add prefix in redis sink key to adapt the business

### DIFF
--- a/chunjun-connectors/chunjun-connector-redis/src/main/java/com/dtstack/chunjun/connector/redis/converter/RedisColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-redis/src/main/java/com/dtstack/chunjun/connector/redis/converter/RedisColumnConverter.java
@@ -184,15 +184,14 @@ public class RedisColumnConverter extends AbstractRowConverter<Object, Object, J
     }
 
     private String concatKey(ColumnRowData row) {
-        if (redisConf.getKeyIndexes().size() == 1) {
-            return String.valueOf(row.getField(redisConf.getKeyIndexes().get(0)));
-        } else {
-            List<String> keys = new ArrayList<>(redisConf.getKeyIndexes().size());
-            for (Integer index : redisConf.getKeyIndexes()) {
-                keys.add(String.valueOf(row.getField(index)));
-            }
-            return StringUtils.join(keys, redisConf.getKeyFieldDelimiter());
+        List<String> keys = new ArrayList<>(redisConf.getKeyIndexes().size() + 1);
+        if (StringUtils.isNotEmpty(redisConf.getKeyPrefix())) {
+            keys.add(redisConf.getKeyPrefix());
         }
+        for (Integer index : redisConf.getKeyIndexes()) {
+            keys.add(String.valueOf(row.getField(redisConf.getKeyIndexes().get(index))));
+        }
+        return StringUtils.join(keys, redisConf.getKeyFieldDelimiter());
     }
 
     private String concatHashKey(ColumnRowData row) {


### PR DESCRIPTION
We can config our redis key with what we like to describe to identify our business by setting a field called “keyPrefix” in redis conf.
[755](https://github.com/DTStack/chunjun/issues/755)