### PR TITLE
[hotfix-842][chunjun-sql]  add excluded file of chunjun-ddl-mysql jar

### DIFF
--- a/chunjun-sql/mysql/pom.xml
+++ b/chunjun-sql/mysql/pom.xml
@@ -49,6 +49,9 @@
 										<exclude>tpch/**</exclude>
 										<exclude>ddl/**</exclude>
 										<exclude>google/**</exclude>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
 									</excludes>
 								</filter>
 							</filters>


### PR DESCRIPTION
1. as what https://github.com/DTStack/chunjun/issues/842 has described, I wrote a script to find out which jar is wrong
```bash
find ./chunjun-dist -name '*.jar' > ./test.txt
while read line
do
    echo $line
    jarsigner -verify $line
done < ./test.txt
```
<img width="757" alt="Screen Shot 2022-06-01 at 2 12 05 PM" src="https://user-images.githubusercontent.com/38547014/171340185-7509f44a-bf28-40fb-9bdb-8bed49a3ec61.png">
2. and fixed the problem.
