### PR TITLE
[hotfix-#764][jdbc]fix duplicate data occurred when use jdbc polling

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/SqlUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/SqlUtil.java
@@ -216,7 +216,7 @@ public class SqlUtil {
             JdbcConf jdbcConf, JdbcDialect jdbcDialect, String sortRule) {
         String column;
         // 增量任务
-        if (jdbcConf.isIncrement() && !jdbcConf.isPolling()) {
+        if (jdbcConf.isIncrement()) {
             column = jdbcConf.getIncreColumn();
         } else {
             column = jdbcConf.getOrderByColumn();

--- a/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/source/PostgresqlInputFormat.java
+++ b/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/source/PostgresqlInputFormat.java
@@ -1,6 +1,7 @@
 package com.dtstack.chunjun.connector.postgresql.source;
 
 import com.dtstack.chunjun.connector.jdbc.source.JdbcInputFormat;
+import com.dtstack.chunjun.connector.jdbc.util.SqlUtil;
 import com.dtstack.chunjun.util.ExceptionUtil;
 
 import java.sql.ResultSet;
@@ -10,15 +11,15 @@ import java.util.concurrent.TimeUnit;
 public class PostgresqlInputFormat extends JdbcInputFormat {
 
     @Override
-    protected void queryStartLocation() throws SQLException {
+    protected void queryPollingWithOutStartLocation() throws SQLException {
         // In PostgreSQL, if resultCursorType is FORWARD_ONLY
         // , the query will report an error after the method
         // #setFetchDirection(ResultSet.FETCH_REVERSE) is called.
+        String querySql =
+                jdbcConf.getQuerySql() + SqlUtil.buildOrderSql(jdbcConf, jdbcDialect, "ASC");
         ps =
                 dbConn.prepareStatement(
-                        jdbcConf.getQuerySql(),
-                        ResultSet.TYPE_SCROLL_INSENSITIVE,
-                        resultSetConcurrency);
+                        querySql, ResultSet.TYPE_SCROLL_INSENSITIVE, resultSetConcurrency);
         ps.setFetchSize(jdbcConf.getFetchSize());
         ps.setQueryTimeout(jdbcConf.getQueryTimeOut());
         resultSet = ps.executeQuery();


### PR DESCRIPTION
1.rename jdbcInputFormat#queryStartLocation to jdbcInputFormat#queryPollingWithoutStartLocation
2.The Polling mode concatenates the Order BY statement when startLocation is set
3.Optimizing duplicate code

#764 