### PR TITLE
provided some shell scripts for reducing parameters to submit a job

### DIFF
--- a/bin/chunjun-kubernetes-application.sh
+++ b/bin/chunjun-kubernetes-application.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE="kubernetes-application"
+
+
+target="$0"
+# For the case, the executable has been directly symlinked, figure out
+# the correct bin path by following its symlink up to an upper bound.
+# Note: we can't use the readlink utility here if we want to be POSIX
+# compatible.
+iteration=0
+while [ -L "$target" ]; do
+    if [ "$iteration" -gt 100 ]; then
+        echo "Cannot resolve path: You have a cyclic symlink in $target."
+        break
+    fi
+    ls=`ls -ld -- "$target"`
+    target=`expr "$ls" : '.* -> \(.*\)$'`
+    iteration=$((iteration + 1))
+done
+
+# Convert relative path to absolute path
+bin=`dirname "$target"`
+
+# get flink config
+. "$bin"/submit.sh  $@

--- a/bin/chunjun-kubernetes-session.sh
+++ b/bin/chunjun-kubernetes-session.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE="kubernetes-session"
+
+
+target="$0"
+# For the case, the executable has been directly symlinked, figure out
+# the correct bin path by following its symlink up to an upper bound.
+# Note: we can't use the readlink utility here if we want to be POSIX
+# compatible.
+iteration=0
+while [ -L "$target" ]; do
+    if [ "$iteration" -gt 100 ]; then
+        echo "Cannot resolve path: You have a cyclic symlink in $target."
+        break
+    fi
+    ls=`ls -ld -- "$target"`
+    target=`expr "$ls" : '.* -> \(.*\)$'`
+    iteration=$((iteration + 1))
+done
+
+# Convert relative path to absolute path
+bin=`dirname "$target"`
+
+# get flink config
+. "$bin"/submit.sh  $@

--- a/bin/chunjun-local.sh
+++ b/bin/chunjun-local.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE="local"
+
+
+target="$0"
+# For the case, the executable has been directly symlinked, figure out
+# the correct bin path by following its symlink up to an upper bound.
+# Note: we can't use the readlink utility here if we want to be POSIX
+# compatible.
+iteration=0
+while [ -L "$target" ]; do
+    if [ "$iteration" -gt 100 ]; then
+        echo "Cannot resolve path: You have a cyclic symlink in $target."
+        break
+    fi
+    ls=`ls -ld -- "$target"`
+    target=`expr "$ls" : '.* -> \(.*\)$'`
+    iteration=$((iteration + 1))
+done
+
+# Convert relative path to absolute path
+bin=`dirname "$target"`
+
+# get flink config
+. "$bin"/submit.sh  $@

--- a/bin/chunjun-standalone.sh
+++ b/bin/chunjun-standalone.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE="standalone"
+
+
+target="$0"
+# For the case, the executable has been directly symlinked, figure out
+# the correct bin path by following its symlink up to an upper bound.
+# Note: we can't use the readlink utility here if we want to be POSIX
+# compatible.
+iteration=0
+while [ -L "$target" ]; do
+    if [ "$iteration" -gt 100 ]; then
+        echo "Cannot resolve path: You have a cyclic symlink in $target."
+        break
+    fi
+    ls=`ls -ld -- "$target"`
+    target=`expr "$ls" : '.* -> \(.*\)$'`
+    iteration=$((iteration + 1))
+done
+
+# Convert relative path to absolute path
+bin=`dirname "$target"`
+
+# get flink config
+. "$bin"/submit.sh

--- a/bin/chunjun-yarn-perjob.sh
+++ b/bin/chunjun-yarn-perjob.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE="yarn-per-job"
+
+
+target="$0"
+# For the case, the executable has been directly symlinked, figure out
+# the correct bin path by following its symlink up to an upper bound.
+# Note: we can't use the readlink utility here if we want to be POSIX
+# compatible.
+iteration=0
+while [ -L "$target" ]; do
+    if [ "$iteration" -gt 100 ]; then
+        echo "Cannot resolve path: You have a cyclic symlink in $target."
+        break
+    fi
+    ls=`ls -ld -- "$target"`
+    target=`expr "$ls" : '.* -> \(.*\)$'`
+    iteration=$((iteration + 1))
+done
+
+# Convert relative path to absolute path
+bin=`dirname "$target"`
+
+# get flink config
+. "$bin"/submit.sh  $@

--- a/bin/chunjun-yarn-session.sh
+++ b/bin/chunjun-yarn-session.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE="yarn-session"
+
+
+target="$0"
+# For the case, the executable has been directly symlinked, figure out
+# the correct bin path by following its symlink up to an upper bound.
+# Note: we can't use the readlink utility here if we want to be POSIX
+# compatible.
+iteration=0
+while [ -L "$target" ]; do
+    if [ "$iteration" -gt 100 ]; then
+        echo "Cannot resolve path: You have a cyclic symlink in $target."
+        break
+    fi
+    ls=`ls -ld -- "$target"`
+    target=`expr "$ls" : '.* -> \(.*\)$'`
+    iteration=$((iteration + 1))
+done
+
+# Convert relative path to absolute path
+bin=`dirname "$target"`
+
+# get flink config
+. "$bin"/submit.sh  $@

--- a/bin/submit.sh
+++ b/bin/submit.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+# Find the java binary
+if [ -n "${JAVA_HOME}" ]; then
+  JAVA_RUN="${JAVA_HOME}/bin/java"
+else
+  if [ `command -v java` ]; then
+    JAVA_RUN="java"
+  else
+    echo "JAVA_HOME is not set" >&2
+    exit 1
+  fi
+fi
+
+export CHUNJUN_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+JAR_DIR=$CHUNJUN_HOME/lib/*
+CLASS_NAME=com.dtstack.chunjun.client.Launcher
+
+JOBTYPE="sync"
+ARGS=$@
+if [[ $ARGS == *.sql* ]];
+  then JOBTYPE="sql"
+fi;
+
+echo "
+          #                               #
+          #                               #
+          #
+  #####   ######   #     #  # ####     ####   #     #  # ####
+ #        #     #  #     #  ##    #       #   #     #  ##    #
+ #        #     #  #     #  #     #       #   #     #  #     #
+ #        #     #  #    ##  #     #       #   #    ##  #     #
+  #####   #     #   #### #  #     #       #    #### #  #     #
+                                          #
+                                      ####
+"
+echo "CHUNJUN_HOME is auto set  $CHUNJUN_HOME"
+echo "FLINK_HOME is $FLINK_HOME"
+echo "HADOOP_HOME is $HADOOP_HOME"
+echo "ChunJun starting ..."
+
+$JAVA_RUN -cp $JAR_DIR $CLASS_NAME $ARGS -mode $MODE -jobType $JOBTYPE -chunjunDistDir $CHUNJUN_HOME -flinkConfDir $FLINK_HOME/conf -flinkLibDir $FLINK_HOME/lib -hadoopConfDir $HADOOP_HOME/etc/hadoop


### PR DESCRIPTION
提供一些脚本，用于减少在不同模式下任务提交需要传入的参数，只需要传递-job和-confProp即可。
其他参数如flink配置文件和hadoop配置文件，通过FLINK_HOME/HADOOP_HOME等参数预先设定。
例如：
在local 模式
```bash
 bash chunjun-local.sh -job ../chunjun-examples/json/stream/stream.json
```
在standalone模式
```bash
 bash chunjun-standalone.sh -job ../chunjun-examples/json/stream/stream.json
```
启动效果
```
 % bash local.sh -job ../chunjun-examples/json/stream/stream.json

CHUNJUN_HOME is auto set  /Users/admin/fsdownload/chunjun-dist
FLINK_HOME is /Users/admin/flink-1.12.4
HADOOP_HOME is /Users/admin/hadoop
ChunJun starting ...
2022-06-09 14:43:37.128 [main] INFO  com.dtstack.chunjun.Main  - ------------program params-------------------------
2022-06-09 14:43:37.165 [main] INFO  com.dtstack.chunjun.Main  - -flinkLibDir
2022-06-09 14:43:37.166 [main] INFO  com.dtstack.chunjun.Main  - /Users/admin/flink-1.12.4/lib
2022-06-09 14:43:37.166 [main] INFO  com.dtstack.chunjun.Main  - -p
2022-06-09 14:43:37.166 [main] INFO  com.dtstack.chunjun.Main  - 
2022-06-09 14:43:37.166 [main] INFO  com.dtstack.chunjun.Main  - -job
```