### PR TITLE
[hotfix-#750][chunjun-connector-kudu] fixed GenericRowData can't conv…

### DIFF
--- a/chunjun-connectors/chunjun-connector-kudu/src/main/java/com/dtstack/chunjun/connector/kudu/converter/KuduColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-kudu/src/main/java/com/dtstack/chunjun/connector/kudu/converter/KuduColumnConverter.java
@@ -32,6 +32,7 @@ import com.dtstack.chunjun.element.column.StringColumn;
 import com.dtstack.chunjun.element.column.TimestampColumn;
 import com.dtstack.chunjun.throwable.UnsupportedTypeException;
 
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -74,7 +75,12 @@ public class KuduColumnConverter
     protected ISerializationConverter<Operation> wrapIntoNullableExternalConverter(
             ISerializationConverter serializationConverter, String type) {
         return (val, index, operation) -> {
-            if (((ColumnRowData) val).getField(index) == null || val.isNullAt(index)) {
+            if (val instanceof ColumnRowData && ((ColumnRowData) val).getField(index) == null
+                    || val.isNullAt(index)) {
+                operation.getRow().setNull(columnName.get(index));
+            } else if (val instanceof GenericRowData
+                            && ((GenericRowData) val).getField(index) == null
+                    || val.isNullAt(index)) {
                 operation.getRow().setNull(columnName.get(index));
             } else {
                 serializationConverter.serialize(val, index, operation);
@@ -183,7 +189,7 @@ public class KuduColumnConverter
                                 .getRow()
                                 .addDecimal(
                                         columnName.get(index),
-                                        ((ColumnRowData) val).getField(index).asBigDecimal());
+                                        val.getDecimal(index, 38, 18).toBigDecimal());
             case "VARCHAR":
                 return (val, index, operation) ->
                         operation
@@ -195,7 +201,7 @@ public class KuduColumnConverter
                                 .getRow()
                                 .addDate(
                                         columnName.get(index),
-                                        ((ColumnRowData) val).getField(index).asSqlDate());
+                                        new Date(val.getTimestamp(index, 6).getMillisecond()));
 
             case "TIMESTAMP":
             case "TIMESTAMP_WITHOUT_TIME_ZONE":
@@ -204,7 +210,7 @@ public class KuduColumnConverter
                                 .getRow()
                                 .addTimestamp(
                                         columnName.get(index),
-                                        ((ColumnRowData) val).getField(index).asTimestamp());
+                                        val.getTimestamp(index, 6).toTimestamp());
             default:
                 throw new UnsupportedTypeException(type);
         }

--- a/chunjun-connectors/chunjun-connector-kudu/src/main/java/com/dtstack/chunjun/connector/kudu/converter/KuduRowConverter.java
+++ b/chunjun-connectors/chunjun-connector-kudu/src/main/java/com/dtstack/chunjun/connector/kudu/converter/KuduRowConverter.java
@@ -21,7 +21,6 @@ package com.dtstack.chunjun.connector.kudu.converter;
 import com.dtstack.chunjun.converter.AbstractRowConverter;
 import com.dtstack.chunjun.converter.IDeserializationConverter;
 import com.dtstack.chunjun.converter.ISerializationConverter;
-import com.dtstack.chunjun.element.ColumnRowData;
 import com.dtstack.chunjun.throwable.UnsupportedTypeException;
 
 import org.apache.flink.table.data.DecimalData;
@@ -40,6 +39,7 @@ import org.apache.kudu.client.RowResult;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -139,7 +139,7 @@ public class KuduRowConverter
                 return val -> (int) Date.valueOf(String.valueOf(val)).toLocalDate().toEpochDay();
             case "TIMESTAMP":
             case "TIMESTAMP_WITHOUT_TIME_ZONE":
-                return val -> TimestampData.fromEpochMillis(((java.util.Date) val).getTime());
+                return val -> TimestampData.fromTimestamp((Timestamp) val);
             case "BINARY":
                 return val -> (byte[]) val;
             default:
@@ -187,7 +187,7 @@ public class KuduRowConverter
                                 .getRow()
                                 .addDecimal(
                                         columnName.get(index),
-                                        ((ColumnRowData) val).getField(index).asBigDecimal());
+                                        val.getDecimal(index, 38, 18).toBigDecimal());
             case "VARCHAR":
                 return (val, index, operation) ->
                         operation
@@ -199,11 +199,7 @@ public class KuduRowConverter
                                 .getRow()
                                 .addDate(
                                         columnName.get(index),
-                                        Date.valueOf(
-                                                LocalDate.ofEpochDay(
-                                                        ((ColumnRowData) val)
-                                                                .getField(index)
-                                                                .asInt())));
+                                        Date.valueOf(LocalDate.ofEpochDay(val.getInt(index))));
 
             case "TIMESTAMP":
             case "TIMESTAMP_WITHOUT_TIME_ZONE":
@@ -212,7 +208,7 @@ public class KuduRowConverter
                                 .getRow()
                                 .addTimestamp(
                                         columnName.get(index),
-                                        ((ColumnRowData) val).getField(index).asTimestamp());
+                                        val.getTimestamp(index, 6).toTimestamp());
             default:
                 throw new UnsupportedTypeException(type);
         }

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/metrics/RowSizeCalculator.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/metrics/RowSizeCalculator.java
@@ -22,6 +22,8 @@ import com.dtstack.chunjun.element.ColumnRowData;
 import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
 import com.dtstack.chunjun.throwable.UnsupportedTypeException;
 
+import org.apache.flink.table.data.RowData;
+
 import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator;
 
 import java.util.Arrays;
@@ -88,10 +90,15 @@ public abstract class RowSizeCalculator<T> {
         }
     }
 
-    static class SyncCalculator extends RowSizeCalculator<ColumnRowData> {
+    /** 同步流量统计，泛型由ColumnRowData修改为RowData，避免类型转换异常 判断入参类型，并利用不同方式统计流量 */
+    static class SyncCalculator extends RowSizeCalculator<RowData> {
         @Override
-        public long getObjectSize(ColumnRowData object) {
-            return object.getByteSize();
+        public long getObjectSize(RowData object) {
+            if (object instanceof ColumnRowData) {
+                return ((ColumnRowData) object).getByteSize();
+            } else {
+                return ObjectSizeCalculator.getObjectSize(object);
+            }
         }
     }
 


### PR DESCRIPTION
I fixed a bug fixed GenericRowData can't Convert to ColumnRowData avoid ClassCastException the kudu row mapping flink table is GenericRowData,However the chunjun-connector-kudu's code kudu row force convert to ColumnRowData.when use kudusink appear ClassCastException！The issue address is [no.750]
(https://github.com/DTStack/chunjun/issues/750)