### PR TITLE
[hotfix-#987] [chunjun-connector-hdfs] fixed HdfsOrcOutputFormat can't get fullColumnType or fullColumnName from HdfsConf

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
@@ -83,6 +83,7 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
                     hdfsConf.getColumn().stream()
                             .map(FieldConf::getName)
                             .collect(Collectors.toList());
+            hdfsConf.setFullColumnName(fullColumnNameList);
         }
 
         if (CollectionUtils.isNotEmpty(hdfsConf.getFullColumnType())) {
@@ -92,6 +93,7 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
                     hdfsConf.getColumn().stream()
                             .map(FieldConf::getType)
                             .collect(Collectors.toList());
+            hdfsConf.setFullColumnType(fullColumnTypeList);
         }
         compressType = getCompressType();
         super.initVariableFields();


### PR DESCRIPTION
fix:HdfsOrcOutputFormat can't get fullColumnType or Name from HdfsConf https://github.com/DTStack/chunjun/issues/987