### PR TITLE
[hotfix-816][flinkx-connector-oracle] Fixed Oracle RAW Type Apply To Flink Type is TimeStamp ERROR

### DIFF
--- a/chunjun-connectors/chunjun-connector-oracle/src/main/java/com/dtstack/chunjun/connector/oracle/converter/OracleRawTypeConverter.java
+++ b/chunjun-connectors/chunjun-connector-oracle/src/main/java/com/dtstack/chunjun/connector/oracle/converter/OracleRawTypeConverter.java
@@ -82,9 +82,9 @@ public class OracleRawTypeConverter {
                 return DataTypes.DECIMAL(decimalInfo.getPrecision(), decimalInfo.getScale());
             case "DATE":
                 return DataTypes.DATE();
-            case "RAW":
             case "TIMESTAMP":
                 return DataTypes.TIMESTAMP();
+            case "RAW":
             case "LONG RAW":
                 return DataTypes.BYTES();
             case "BLOB":


### PR DESCRIPTION
Fixed Oracle RAW Type Apply To Flink Type is TimeStamp ERROR, Now Oracle RAW Type Apply To Flink Type is BYTES