### PR TITLE
[hotfix-#1042][chunjun-core] repair pluginRoot‘s folder not set , Cau…

### DIFF
--- a/chunjun-core/src/main/java/com/dtstack/chunjun/Main.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/Main.java
@@ -280,6 +280,11 @@ public class Main {
         try {
             config = SyncConf.parseJob(job);
 
+            // 设置chunjun-dist的路径
+            if (StringUtils.isNotBlank(options.getChunjunDistDir())) {
+                config.setPluginRoot(options.getChunjunDistDir());
+            }
+
             Properties confProperties = PropertiesUtil.parseConf(options.getConfProp());
 
             String savePointPath =


### PR DESCRIPTION
I fixed a bug when start chunjun ，The bug is  pluginRoot's folder is not set, Causes the class to fail to load The issue address is [no.1042]
(https://github.com/DTStack/chunjun/issues/1042)