### PR TITLE
[hotfix-#1052][hive] Fix the data loss problem of HiveWriter

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive/src/main/java/com/dtstack/chunjun/connector/hive/sink/HiveOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hive/src/main/java/com/dtstack/chunjun/connector/hive/sink/HiveOutputFormat.java
@@ -246,8 +246,8 @@ public class HiveOutputFormat extends BaseRichOutputFormat {
                 outputFormatMap.entrySet()) {
             try {
                 BaseHdfsOutputFormat format = entry.getValue().getRight();
-                format.finalizeGlobal(numTasks);
                 format.close();
+                format.finalizeGlobal(numTasks);
             } catch (IOException e) {
                 LOG.warn("close {} outputFormat error", entry.getKey(), e);
             }


### PR DESCRIPTION
Replace the call order of HDFSOutputFormat Close and finalizeGlobal

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

## Which issue you fix
Fixes # (issue).
#1052 

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
