### PR TITLE
[feature] Support for regular expressions for mysql sub-database and sub-table

### DIFF
--- a/chunjun-connectors/chunjun-connector-mysqlm/pom.xml
+++ b/chunjun-connectors/chunjun-connector-mysqlm/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>chunjun-connectors</artifactId>
+		<groupId>com.dtstack.chunjun</groupId>
+		<version>1.12-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>chunjun-connector-mysqlm</artifactId>
+	<name>ChunJun : Connectors : MySQL Distribute</name>
+
+	<properties>
+		<connector.dir>mysqlm</connector.dir>
+		<mysql.version>5.1.46</mysql.version>
+		<druid.version>1.2.8</druid.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.dtstack.chunjun</groupId>
+			<artifactId>chunjun-connector-jdbc-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.dtstack.chunjun</groupId>
+			<artifactId>chunjun-connector-mysql</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>${mysql.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.alibaba</groupId>
+			<artifactId>druid</artifactId>
+			<version>${druid.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<artifactSet>
+								<excludes>
+									<exclude>org.slf4j:slf4j-api</exclude>
+									<exclude>log4j:log4j</exclude>
+									<exclude>ch.qos.logback:*</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/chunjun-connectors/chunjun-connector-mysqlm/src/main/java/com/dtstack/chunjun/connector/mysqlm/source/MysqlmSourceFactory.java
+++ b/chunjun-connectors/chunjun-connector-mysqlm/src/main/java/com/dtstack/chunjun/connector/mysqlm/source/MysqlmSourceFactory.java
@@ -1,0 +1,142 @@
+package com.dtstack.chunjun.connector.mysqlm.source;
+
+import com.dtstack.chunjun.conf.SyncConf;
+import com.dtstack.chunjun.connector.jdbc.conf.ConnectionConf;
+import com.dtstack.chunjun.connector.jdbc.conf.DataSourceConf;
+import com.dtstack.chunjun.connector.jdbc.source.JdbcInputFormatBuilder;
+import com.dtstack.chunjun.connector.jdbc.source.distribute.DistributedJdbcInputFormat;
+import com.dtstack.chunjun.connector.jdbc.source.distribute.DistributedJdbcInputFormatBuilder;
+import com.dtstack.chunjun.connector.jdbc.source.distribute.DistributedJdbcSourceFactory;
+import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
+import com.dtstack.chunjun.connector.mysql.dialect.MysqlDialect;
+import com.dtstack.chunjun.connector.mysqlm.utils.MySqlDataSource;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MysqlmSourceFactory extends DistributedJdbcSourceFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MysqlmSourceFactory.class);
+
+    private final AtomicInteger jdbcPatternCounter = new AtomicInteger(0);
+    private final AtomicInteger jdbcTableCounter = new AtomicInteger(0);
+
+    public MysqlmSourceFactory(SyncConf syncConf, StreamExecutionEnvironment env) {
+        super(syncConf, env, new MysqlDialect());
+        JdbcUtil.putExtParam(jdbcConf);
+    }
+
+    @Override
+    protected JdbcInputFormatBuilder getBuilder() {
+        DistributedJdbcInputFormatBuilder builder =
+                new DistributedJdbcInputFormatBuilder(new DistributedJdbcInputFormat());
+        List<ConnectionConf> connectionConfList = jdbcConf.getConnection();
+        List<DataSourceConf> dataSourceConfList = new ArrayList<>(connectionConfList.size());
+        try {
+            /** 可以是多个 connection、多个 database、多个 table， 或者 正则匹配的 database、table */
+            for (ConnectionConf connectionConf : connectionConfList) {
+                String currentUsername =
+                        (StringUtils.isNotBlank(connectionConf.getUsername()))
+                                ? connectionConf.getUsername()
+                                : jdbcConf.getUsername();
+                String currentPassword =
+                        (StringUtils.isNotBlank(connectionConf.getPassword()))
+                                ? connectionConf.getPassword()
+                                : jdbcConf.getPassword();
+                String jdbcUrl = connectionConf.obtainJdbcUrl();
+                Connection connection =
+                        MySqlDataSource.getDataSource(jdbcUrl, currentUsername, currentPassword)
+                                .getConnection();
+                for (String table : connectionConf.getTable()) {
+                    dataSourceConfList.addAll(
+                            allTables(
+                                    connection,
+                                    connectionConf.getSchema(),
+                                    jdbcUrl,
+                                    currentUsername,
+                                    currentPassword,
+                                    table));
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Configuration resolution exception.....");
+        }
+        builder.setSourceList(dataSourceConfList);
+        return builder;
+    }
+
+    public List<DataSourceConf> allTables(
+            Connection connection,
+            String currSchema,
+            String url,
+            String user,
+            String pass,
+            String currTable)
+            throws SQLException {
+        Map<String, List<String>> tables = new HashMap<>();
+        List<DataSourceConf> dataSourceConfList = new ArrayList<>();
+
+        Pattern schema = Pattern.compile(currSchema);
+        Pattern table = Pattern.compile(currTable);
+        DatabaseMetaData metaData = connection.getMetaData();
+        ResultSet catalogs = metaData.getCatalogs();
+        while (catalogs.next()) {
+            String schemaName = catalogs.getString(1);
+            Matcher matcher = schema.matcher(schemaName);
+            if (matcher.matches()) {
+                tables.put(schemaName, new ArrayList<>());
+            }
+        }
+        for (String schemaName : tables.keySet()) {
+            ResultSet tableResult = metaData.getTables(currSchema, null, null, null);
+            while (tableResult.next()) {
+                String tableName = tableResult.getString("TABLE_NAME");
+                LOG.info(
+                        "query table [{}]: {}, table: {}.{}",
+                        jdbcTableCounter.incrementAndGet(),
+                        url,
+                        schema,
+                        tableName);
+                Matcher matcher = table.matcher(tableName);
+                if (matcher.matches()) {
+                    tables.get(schemaName).add(tableName);
+                }
+            }
+        }
+
+        for (String key : tables.keySet()) {
+            for (String mTable : tables.get(key)) {
+                DataSourceConf dataSourceConf = new DataSourceConf();
+                dataSourceConf.setJdbcUrl(url);
+                dataSourceConf.setUserName(user);
+                dataSourceConf.setPassword(pass);
+                dataSourceConf.setSchema(key);
+                dataSourceConf.setTable(mTable);
+                LOG.info(
+                        "pattern jdbcurl: [{}] {}, table: {}.{}",
+                        jdbcPatternCounter.incrementAndGet(),
+                        url,
+                        key,
+                        mTable);
+                dataSourceConfList.add(dataSourceConf);
+            }
+        }
+        return dataSourceConfList;
+    }
+}

--- a/chunjun-connectors/chunjun-connector-mysqlm/src/main/java/com/dtstack/chunjun/connector/mysqlm/utils/MySqlDataSource.java
+++ b/chunjun-connectors/chunjun-connector-mysqlm/src/main/java/com/dtstack/chunjun/connector/mysqlm/utils/MySqlDataSource.java
@@ -1,0 +1,42 @@
+package com.dtstack.chunjun.connector.mysqlm.utils;
+
+import com.alibaba.druid.pool.DruidDataSource;
+
+import javax.sql.DataSource;
+
+import java.sql.SQLException;
+import java.util.Collections;
+
+public class MySqlDataSource {
+
+    private static final String DRIVER = "com.mysql.jdbc.Driver";
+
+    public static DataSource getDataSource(String jdbcUrl, String username, String password)
+            throws SQLException {
+        DruidDataSource dataSource = new DruidDataSource();
+        dataSource.setDriverClassName(DRIVER);
+        dataSource.setUrl(jdbcUrl);
+        dataSource.setUsername(username);
+        dataSource.setPassword(password);
+        dataSource.setInitialSize(1);
+        dataSource.setMinIdle(1);
+        dataSource.setMaxActive(5);
+        dataSource.setMaxWait(30000);
+        dataSource.setTimeBetweenEvictionRunsMillis(60000);
+        dataSource.setMinEvictableIdleTimeMillis(300000);
+        dataSource.setTestWhileIdle(true);
+        dataSource.setTestOnBorrow(false);
+        dataSource.setTestOnReturn(false);
+        dataSource.setKeepAlive(true);
+        dataSource.setPoolPreparedStatements(false);
+        dataSource.setConnectionInitSqls(Collections.singletonList("set names 'utf8'"));
+
+        dataSource.setRemoveAbandoned(false);
+        dataSource.setLogAbandoned(true);
+        dataSource.setTimeBetweenConnectErrorMillis(60000);
+        dataSource.setConnectionErrorRetryAttempts(3);
+        dataSource.init();
+
+        return dataSource;
+    }
+}

--- a/chunjun-connectors/pom.xml
+++ b/chunjun-connectors/pom.xml
@@ -77,7 +77,8 @@
 
 		<!--Distribute plugin, just for SYNC-->
 		<module>chunjun-connector-mysqld</module>
-	</modules>
+        <module>chunjun-connector-mysqlm</module>
+    </modules>
 
 
 	<dependencies>

--- a/chunjun-examples/json/mysqlm/mysqlm.json
+++ b/chunjun-examples/json/mysqlm/mysqlm.json
@@ -1,0 +1,102 @@
+{
+  "job": {
+    "content": [
+      {
+        "reader": {
+          "parameter": {
+            "column": [
+              {
+                "name": "id",
+                "type": "int"
+              },
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "address",
+                "type": "string"
+              },
+              {
+                "name": "phone_number",
+                "type": "string"
+              },
+              {
+                "name": "email",
+                "type": "string"
+              }
+            ],
+            "connection": [
+              {
+                "password": "xxxx",
+                "jdbcUrl": [
+                  "jdbc:mysql://127.0.0.1:3306/kinodb?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
+                ],
+                "table": ["user_7", "user_8", "user_9"],
+                "username": "root",
+                "schema": "kinodb"
+              },
+              {
+                "password": "xxxx",
+                "jdbcUrl": [
+                  "jdbc:mysql://127.0.0.1:3307/kinodb?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
+                ],
+                "table": ["user_20", "dep_[0-1]+"],
+                "username": "root",
+                "schema": "kinodb"
+              },
+              {
+                "password": "xxxx",
+                "jdbcUrl": [
+                  "jdbc:mysql://127.0.0.1:3308/kinodb?useUnicode=true&characterEncoding=UTF-8&useSSL=false"
+                ],
+                "table": ["user_[0-9]+"],
+                "username": "root",
+                "schema": "kinodb_[0-9]+"
+              }
+            ]
+          },
+          "name": "mysqlmreader"
+        },
+        "writer": {
+          "parameter": {
+            "column": [
+              {
+                "name": "id",
+                "type": "int"
+              },
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "address",
+                "type": "string"
+              },
+              {
+                "name": "phone_number",
+                "type": "string"
+              },
+              {
+                "name": "email",
+                "type": "string"
+              }
+            ],
+            "print": true
+          },
+          "table": {
+            "tableName": "sinkTable"
+          },
+          "name": "streamwriter"
+        }
+      }
+    ],
+    "setting": {
+      "speed": {
+        "readerChannel": 1,
+        "writerChannel": 1,
+        "channel": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
支持mysql分库分表的正则表达式配置

# 配置文件参数说明
1. connection：可以配置一个或多个；
2. jdbcUrl：一个 connection 目前只支持一个 jdbcUrl；
3. table：可以配置一个或多个表，或者是正则表达式(表和正则表达式混写)；
4. schema：可以写库名，或者是正则表达式。

[详细配置查看](chunjun-examples/json/mysqlm/mysqlm.json)