### PR TITLE
[hotfix-#1119][pgsql] Connection cast-exception when use greenplum sink.

### DIFF
--- a/chunjun-connectors/chunjun-connector-greenplum/src/main/java/com/dtstack/chunjun/connector/greenplum/sink/GreenplumSinkFactory.java
+++ b/chunjun-connectors/chunjun-connector-greenplum/src/main/java/com/dtstack/chunjun/connector/greenplum/sink/GreenplumSinkFactory.java
@@ -19,6 +19,7 @@
 package com.dtstack.chunjun.connector.greenplum.sink;
 
 import com.dtstack.chunjun.conf.SyncConf;
+import com.dtstack.chunjun.connector.greenplum.dialect.GreenplumDialect;
 import com.dtstack.chunjun.connector.postgresql.sink.PostgresqlSinkFactory;
 
 /**
@@ -29,6 +30,6 @@ import com.dtstack.chunjun.connector.postgresql.sink.PostgresqlSinkFactory;
 public class GreenplumSinkFactory extends PostgresqlSinkFactory {
 
     public GreenplumSinkFactory(SyncConf syncConf) {
-        super(syncConf);
+        super(syncConf, new GreenplumDialect());
     }
 }

--- a/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/sink/PostgresOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/sink/PostgresOutputFormat.java
@@ -88,10 +88,10 @@ public class PostgresOutputFormat extends JdbcOutputFormat {
                 LOG.info("write sql:{}", copySql);
             }
             checkUpsert();
-            if (rowConverter instanceof PostgresqlColumnConverter) {
+            if (jdbcDialect.dialectName().equals("PostgreSQL")) {
                 ((PostgresqlColumnConverter) rowConverter).setConnection((BaseConnection) dbConn);
-                ((PostgresqlColumnConverter) rowConverter).setFieldTypeList(columnTypeList);
             }
+            ((PostgresqlColumnConverter) rowConverter).setFieldTypeList(columnTypeList);
         } catch (SQLException sqe) {
             throw new IllegalArgumentException("checkUpsert() failed.", sqe);
         }

--- a/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/sink/PostgresqlSinkFactory.java
+++ b/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/sink/PostgresqlSinkFactory.java
@@ -19,6 +19,7 @@
 package com.dtstack.chunjun.connector.postgresql.sink;
 
 import com.dtstack.chunjun.conf.SyncConf;
+import com.dtstack.chunjun.connector.jdbc.dialect.JdbcDialect;
 import com.dtstack.chunjun.connector.jdbc.sink.JdbcOutputFormatBuilder;
 import com.dtstack.chunjun.connector.jdbc.sink.JdbcSinkFactory;
 import com.dtstack.chunjun.connector.postgresql.dialect.PostgresqlDialect;
@@ -34,6 +35,10 @@ public class PostgresqlSinkFactory extends JdbcSinkFactory {
 
     public PostgresqlSinkFactory(SyncConf syncConf) {
         super(syncConf, new PostgresqlDialect());
+    }
+
+    public PostgresqlSinkFactory(SyncConf syncConf, JdbcDialect dialect) {
+        super(syncConf, dialect);
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

 Fix the issue of throwing connection cast-exception when use greenplum-writer.

## Which issue you fix
Fixes # (1119).

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
