### PR TITLE
[hotfix-1147] classNotFound com.google.commom.cache.CacheBuilder

### DIFF
--- a/chunjun-core/pom.xml
+++ b/chunjun-core/pom.xml
@@ -348,10 +348,6 @@
 							</artifactSet>
 							<relocations>
 								<relocation>
-									<pattern>com.google.common</pattern>
-									<shadedPattern>shade.core.com.google.common</shadedPattern>
-								</relocation>
-								<relocation>
 									<pattern>com.google.thirdparty</pattern>
 									<shadedPattern>shade.core.com.google.thirdparty</shadedPattern>
 								</relocation>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->
Chunjun core exclude all guava package, and shade rename guava cause standalone mode NoDefClassFound.

## Which issue you fix
Fixes # (1147).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
