### PR TITLE
[hotfix-simple][#fix-bin]#fix-commit

### DIFF
--- a/bin/submit.sh
+++ b/bin/submit.sh
@@ -31,12 +31,26 @@ else
   fi
 fi
 
+#1: deploy with assembly dist package file
+#2: deploy with project package
+CHUNJUN_DEPLOY_MODE=1
 if [[ $CHUNJUN_HOME && -z $CHUNJUN_HOME ]];then
-    export CHUNJUN_HOME=$CHUNJUN_HOME
+  export CHUNJUN_HOME=$CHUNJUN_HOME
 else
-    export CHUNJUN_HOME="$(cd "`dirname "$0"`"/../chunjun-dist; pwd)"
+  CHUNJUN_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+  if [ -d "$CHUNJUN_HOME/chunjun-dist" ]; then
+    CHUNJUN_HOME="$CHUNJUN_HOME/chunjun-dist"
+    CHUNJUN_DEPLOY_MODE=2
+  fi
 fi
-JAR_DIR=$CHUNJUN_HOME/../lib/*
+# 1.In yarn-session case, JAR_DIR can not be found
+# 2.In other cases, JAR_DIR can be found
+if [ $CHUNJUN_DEPLOY_MODE -eq 1 ]; then
+  JAR_DIR=$CHUNJUN_HOME/lib/*
+else
+  JAR_DIR=$CHUNJUN_HOME/../lib/*
+fi
+
 CLASS_NAME=com.dtstack.chunjun.client.Launcher
 
 JOBTYPE="sync"


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
fix the problem1:  when invoking a starting script such as chunjun-yarn-perjob.sh with the correct CHUNJUN_HOME env var, chunjun program fails cause "cd XXX/../chunjun_dist not found"

fix the problem2: when invoking a starting script such as chunjun-yarn-perjob.sh with the correct CHUNJUN_HOME env var, chunjun program can not load right classpath because of the wrong classpath path setting "xxx/chunjun-dist/../lib“

## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
