### PR TITLE
[hotfix][clients] avoid unnecessary error message of logfile.

### DIFF
--- a/chunjun-clients/src/main/resources/log4j.properties
+++ b/chunjun-clients/src/main/resources/log4j.properties
@@ -3,8 +3,8 @@
 #############
 
 # log4j.rootLogger日志输出类别和级别：只输出不低于该级别的日志信息 DEBUG < INFO < WARN < ERROR < FATAL
-# WARN：日志级别     CONSOLE：输出位置自己定义的一个名字       logfile：输出位置自己定义的一个名字
-log4j.rootLogger=INFO,CONSOLE,logfile
+# WARN：日志级别     CONSOLE：输出位置自己定义的一个名字
+log4j.rootLogger=INFO,CONSOLE
 # 配置CONSOLE输出到控制台
 log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 # 配置CONSOLE设置为自定义布局模式


### PR DESCRIPTION

## Purpose of this pull request
 Error message of log4j raised while we submitted job from client side.
error message:
```
log4j:ERROR Could not find value for key log4j.appender.logfile
log4j:ERROR Could not instantiate appender named "logfile".
```
since we haven't define any configuration of logfile in log4j properties and we can't modify this file, it can be deleted.