### PR TITLE
[feat][jdbc] Add keyUtil to handle special columns

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/conf/JdbcConf.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/conf/JdbcConf.java
@@ -66,6 +66,8 @@ public class JdbcConf extends ChunJunCommonConf implements Serializable {
     private boolean polling = false;
     /** 字段名称 */
     private String increColumn;
+    /** Whether an OrderBy sort is required,increment mode need set to true. */
+    private boolean isOrderBy = true;
     /** 字段索引 */
     private int increColumnIndex = -1;
     /** 字段类型 */
@@ -293,6 +295,14 @@ public class JdbcConf extends ChunJunCommonConf implements Serializable {
 
     public void setIncreColumn(String increColumn) {
         this.increColumn = increColumn;
+    }
+
+    public boolean isOrderBy() {
+        return isOrderBy;
+    }
+
+    public void setOrderBy(boolean orderBy) {
+        isOrderBy = orderBy;
     }
 
     public int getIncreColumnIndex() {

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcInputFormat.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcInputFormat.java
@@ -22,6 +22,7 @@ import com.dtstack.chunjun.connector.jdbc.conf.JdbcConf;
 import com.dtstack.chunjun.connector.jdbc.dialect.JdbcDialect;
 import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
 import com.dtstack.chunjun.connector.jdbc.util.SqlUtil;
+import com.dtstack.chunjun.connector.jdbc.util.key.KeyUtil;
 import com.dtstack.chunjun.constants.ConstantValue;
 import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.enums.ColumnType;
@@ -34,7 +35,6 @@ import com.dtstack.chunjun.throwable.ReadRecordException;
 import com.dtstack.chunjun.util.ColumnBuildUtil;
 import com.dtstack.chunjun.util.ExceptionUtil;
 import com.dtstack.chunjun.util.GsonUtil;
-import com.dtstack.chunjun.util.StringUtil;
 import com.dtstack.chunjun.util.TableUtil;
 
 import org.apache.flink.core.io.InputSplit;
@@ -47,12 +47,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -60,9 +58,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-
-import static com.dtstack.chunjun.enums.ColumnType.TIMESTAMPTZ;
 
 /**
  * InputFormat for reading data from a database and generate Rows.
@@ -98,6 +93,9 @@ public class JdbcInputFormat extends BaseRichInputFormat {
     protected ColumnType type;
 
     protected JdbcInputSplit currentJdbcInputSplit;
+    protected KeyUtil<?, BigInteger> incrementKeyUtil;
+    protected KeyUtil<?, BigInteger> splitKeyUtil;
+    private KeyUtil<?, BigInteger> restoreKeyUtil;
 
     @Override
     public void openInternal(InputSplit inputSplit) {
@@ -256,7 +254,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
                     }
                     dbConn.setAutoCommit(true);
                     JdbcUtil.closeDbResources(resultSet, null, null, false);
-                    queryForPolling(String.valueOf(state));
+                    queryForPolling(restoreKeyUtil.transToLocationValue(state).toString());
                     return false;
                 } catch (InterruptedException e) {
                     LOG.warn(
@@ -286,19 +284,10 @@ public class JdbcInputFormat extends BaseRichInputFormat {
             @SuppressWarnings("unchecked")
             RowData finalRowData = rowConverter.toInternal(resultSet);
             if (needUpdateEndLocation) {
-                Object obj;
-                switch (type) {
-                    case DATETIME:
-                    case TIMESTAMP:
-                    case TIMESTAMPTZ:
-                    case DATE:
-                        obj = resultSet.getTimestamp(jdbcConf.getIncreColumn()).getTime();
-                        break;
-                    default:
-                        obj = resultSet.getObject(jdbcConf.getIncreColumn());
-                }
-                String location = String.valueOf(obj);
-                endLocationAccumulator.add(new BigInteger(location));
+                BigInteger location =
+                        incrementKeyUtil.getLocationValueFromRs(
+                                resultSet, jdbcConf.getIncreColumnIndex() + 1);
+                endLocationAccumulator.add(location);
                 LOG.debug("update endLocationAccumulator, current Location = {}", location);
             }
             if (jdbcConf.getRestoreColumnIndex() > -1) {
@@ -343,8 +332,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
         startLocationAccumulator = new BigIntegerAccumulator();
         endLocationAccumulator = new BigIntegerAccumulator();
         JdbcInputSplit jdbcInputSplit = (JdbcInputSplit) inputSplit;
-        String startLocation =
-                StringUtil.stringToTimestampStr(jdbcInputSplit.getStartLocation(), type);
+        String startLocation = jdbcInputSplit.getStartLocation();
 
         if (StringUtils.isNotBlank(startLocation)) {
             startLocationAccumulator.add(new BigInteger(startLocation));
@@ -355,10 +343,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
             // 若useMaxFunc设置为true，endLocation设置为数据库中查询的最大值
             if (jdbcConf.isUseMaxFunc()) {
                 getMaxValue(inputSplit);
-                endLocationAccumulator.add(
-                        new BigInteger(
-                                StringUtil.stringToTimestampStr(
-                                        jdbcInputSplit.getEndLocation(), type)));
+                endLocationAccumulator.add(new BigInteger(jdbcInputSplit.getEndLocation()));
             } else {
                 // useMaxFunc设置为false，如果startLocation不为空，则将endLocation初始值设置为startLocation的值，防止数据库无增量数据时下次获取到的startLocation为空
                 if (StringUtils.isNotEmpty(startLocation)) {
@@ -442,7 +427,6 @@ public class JdbcInputFormat extends BaseRichInputFormat {
 
             String startSql =
                     buildStartLocationSql(
-                            jdbcConf.getIncreColumnType(),
                             jdbcDialect.quoteIdentifier(jdbcConf.getIncreColumn()),
                             jdbcConf.getStartLocation(),
                             jdbcConf.isUseMaxFunc(),
@@ -458,18 +442,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
             st.setQueryTimeout(jdbcConf.getQueryTimeOut());
             rs = st.executeQuery(queryMaxValueSql);
             if (rs.next()) {
-                switch (type) {
-                    case TIMESTAMP:
-                        maxValue = String.valueOf(rs.getTimestamp("max_value").getTime());
-                        break;
-                    case DATE:
-                        maxValue = String.valueOf(rs.getDate("max_value").getTime());
-                        break;
-                    default:
-                        maxValue =
-                                StringUtil.stringToTimestampStr(
-                                        String.valueOf(rs.getObject("max_value")), type);
-                }
+                maxValue = incrementKeyUtil.getLocationValueFromRs(rs, "max_value").toString();
             }
 
             LOG.info(
@@ -575,18 +548,13 @@ public class JdbcInputFormat extends BaseRichInputFormat {
     /**
      * 构建起始位置sql
      *
-     * @param incrementColType 增量字段类型
      * @param incrementCol 增量字段名称
      * @param startLocation 开始位置
      * @param useMaxFunc 是否保存结束位置数据
      * @return
      */
     public String buildStartLocationSql(
-            String incrementColType,
-            String incrementCol,
-            String startLocation,
-            boolean useMaxFunc,
-            boolean isPolling) {
+            String incrementCol, String startLocation, boolean useMaxFunc, boolean isPolling) {
         if (org.apache.commons.lang.StringUtils.isEmpty(startLocation)
                 || JdbcUtil.NULL_STRING.equalsIgnoreCase(startLocation)) {
             return null;
@@ -599,54 +567,26 @@ public class JdbcInputFormat extends BaseRichInputFormat {
             return incrementCol + operator + "?";
         }
 
-        return getLocationSql(incrementColType, incrementCol, startLocation, operator);
+        return getLocationSql(incrementCol, startLocation, operator);
     }
 
     /**
      * 构建边界位置sql
      *
-     * @param incrementColType 增量字段类型
      * @param incrementCol 增量字段名称
      * @param location 边界位置(起始/结束)
      * @param operator 判断符( >, >=, <)
      * @return
      */
-    protected String getLocationSql(
-            String incrementColType, String incrementCol, String location, String operator) {
-        String endTimeStr;
+    protected String getLocationSql(String incrementCol, String location, String operator) {
         String endLocationSql;
-        ColumnType type = ColumnType.fromString(incrementColType);
-        if (type == TIMESTAMPTZ) {
-            return String.valueOf(Timestamp.valueOf(location).getTime());
-        }
-        if (ColumnType.isTimeType(incrementColType)) {
-            endTimeStr = getTimeStr(Long.parseLong(location));
-            endLocationSql = incrementCol + operator + endTimeStr;
-        } else if (ColumnType.isNumberType(incrementColType)) {
-            endLocationSql = incrementCol + operator + location;
-        } else {
-            endTimeStr = String.format("'%s'", location);
-            endLocationSql = incrementCol + operator + endTimeStr;
-        }
+
+        endLocationSql =
+                incrementCol
+                        + operator
+                        + incrementKeyUtil.transLocationStrToStatementValue(location);
 
         return endLocationSql;
-    }
-
-    /**
-     * 构建时间边界字符串
-     *
-     * @param location 边界位置(起始/结束)
-     * @return
-     */
-    protected String getTimeStr(Long location) {
-        String timeStr;
-        Timestamp ts = new Timestamp(JdbcUtil.getMillis(location));
-        ts.setNanos(JdbcUtil.getNanos(location));
-        timeStr = JdbcUtil.getNanosTimeStr(ts.toString());
-        timeStr = timeStr.substring(0, 26);
-        timeStr = String.format("'%s'", timeStr);
-
-        return timeStr;
     }
 
     /**
@@ -663,79 +603,52 @@ public class JdbcInputFormat extends BaseRichInputFormat {
             LOG.debug("polling startLocation = {}", startLocation);
         }
 
-        boolean isNumber = StringUtils.isNumeric(startLocation);
-        switch (type) {
-            case TIMESTAMP:
-            case TIMESTAMPTZ:
-            case DATETIME:
-                Timestamp ts =
-                        isNumber
-                                ? new Timestamp(Long.parseLong(startLocation))
-                                : Timestamp.valueOf(startLocation);
-                ps.setTimestamp(1, ts);
-                break;
-            case DATE:
-                Date date =
-                        isNumber
-                                ? new Date(Long.parseLong(startLocation))
-                                : Date.valueOf(startLocation);
-                ps.setDate(1, date);
-                break;
-            default:
-                if (isNumber) {
-                    ps.setLong(1, Long.parseLong(startLocation));
-                } else {
-                    ps.setString(1, startLocation);
-                }
-        }
+        incrementKeyUtil.setPsWithLocationStr(ps, 1, startLocation);
         resultSet = ps.executeQuery();
         hasNext = resultSet.next();
     }
 
     /** 构建基于startLocation&endLocation的过滤条件 * */
     protected void buildLocationFilter(JdbcInputSplit jdbcInputSplit, List<String> whereList) {
-        String startLocation = jdbcInputSplit.getStartLocation();
         if (formatState.getState() != null && StringUtils.isNotBlank(jdbcConf.getRestoreColumn())) {
-            startLocation = String.valueOf(formatState.getState());
-            if (StringUtils.isNotBlank(startLocation)) {
-                LOG.info(
-                        "restore from checkpoint, update startLocation, before = {}, after = {}",
-                        jdbcInputSplit.getStartLocation(),
-                        startLocation);
-                jdbcInputSplit.setStartLocation(startLocation);
+            if (StringUtils.isNotBlank(String.valueOf(formatState.getState()))) {
+                LOG.info("restore from checkpoint with state{}", formatState.getState());
+                if (jdbcConf.isIncrement()) {
+                    jdbcInputSplit.setStartLocation(
+                            incrementKeyUtil
+                                    .transToLocationValue(formatState.getState())
+                                    .toString());
+                }
                 whereList.add(
                         buildFilterSql(
                                 jdbcConf.getCustomSql(),
                                 ">",
-                                startLocation,
                                 jdbcDialect.quoteIdentifier(jdbcConf.getRestoreColumn()),
-                                jdbcConf.getRestoreColumnType(),
                                 jdbcInputSplit.isPolling(),
-                                this::getTimeStr));
+                                restoreKeyUtil.transToStatementValue(formatState.getState())));
             }
         } else if (jdbcConf.isIncrement()) {
+            String startLocation = jdbcInputSplit.getStartLocation();
             if (StringUtils.isNotBlank(startLocation)) {
                 String operator = jdbcConf.isUseMaxFunc() ? " >= " : " > ";
                 whereList.add(
                         buildFilterSql(
                                 jdbcConf.getCustomSql(),
                                 operator,
-                                startLocation,
                                 jdbcDialect.quoteIdentifier(jdbcConf.getIncreColumn()),
-                                jdbcConf.getIncreColumnType(),
                                 jdbcInputSplit.isPolling(),
-                                this::getTimeStr));
+                                incrementKeyUtil.transLocationStrToStatementValue(
+                                        jdbcInputSplit.getStartLocation())));
             }
             if (StringUtils.isNotBlank(jdbcInputSplit.getEndLocation())) {
                 whereList.add(
                         buildFilterSql(
                                 jdbcConf.getCustomSql(),
                                 "<",
-                                jdbcInputSplit.getEndLocation(),
                                 jdbcDialect.quoteIdentifier(jdbcConf.getIncreColumn()),
-                                jdbcConf.getIncreColumnType(),
                                 false,
-                                this::getTimeStr));
+                                incrementKeyUtil.transLocationStrToStatementValue(
+                                        jdbcInputSplit.getEndLocation())));
             }
         }
     }
@@ -753,8 +666,8 @@ public class JdbcInputFormat extends BaseRichInputFormat {
         BigDecimal left, right = null;
         if (StringUtils.isNotBlank(splitRangeFromDb.getLeft())
                 && !"null".equalsIgnoreCase(splitRangeFromDb.getLeft())) {
-            left = new BigDecimal(splitRangeFromDb.getLeft());
-            right = new BigDecimal(splitRangeFromDb.getRight());
+            left = new BigDecimal(splitKeyUtil.transToLocationValue(splitRangeFromDb.getLeft()));
+            right = new BigDecimal(splitKeyUtil.transToLocationValue(splitRangeFromDb.getRight()));
             splits.addAll(createRangeSplits(left, right, minNumSplits));
             if (jdbcConf.isPolling()) {
                 // rangeSplit in polling mode,range first then mod.we need to change the last range
@@ -823,8 +736,10 @@ public class JdbcInputFormat extends BaseRichInputFormat {
                             i,
                             jdbcConf.getStartLocation(),
                             null,
-                            start.toString(),
-                            Objects.isNull(end) ? null : end.toString(),
+                            splitKeyUtil.transLocationStrToStatementValue(start.toString()),
+                            Objects.isNull(end)
+                                    ? null
+                                    : splitKeyUtil.transLocationStrToStatementValue(end.toString()),
                             "range",
                             false);
         }
@@ -841,6 +756,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
     protected void executeQuery(String startLocation) throws SQLException {
         if (currentJdbcInputSplit.isPolling()) {
             if (StringUtils.isBlank(startLocation)) {
+                // avoid startLocation is null
                 queryPollingWithOutStartLocation();
                 // Concatenated sql statement for next polling query
                 StringBuilder builder = new StringBuilder(128);
@@ -864,7 +780,7 @@ public class JdbcInputFormat extends BaseRichInputFormat {
                                 + SqlUtil.buildOrderSql(jdbcConf, jdbcDialect, "ASC"));
                 initPrepareStatement(jdbcConf.getQuerySql());
                 queryForPolling(startLocation);
-                state = startLocation;
+                state = restoreKeyUtil.transLocationStrToSqlValue(startLocation);
             }
         } else {
             statement = dbConn.createStatement(resultSetType, resultSetConcurrency);
@@ -932,18 +848,15 @@ public class JdbcInputFormat extends BaseRichInputFormat {
      * @param operator 比较符
      * @param location 比较的值
      * @param columnName 字段名称
-     * @param columnType 字段类型
      * @param isPolling 是否是轮询任务
      * @return
      */
     public String buildFilterSql(
             String customSql,
             String operator,
-            String location,
             String columnName,
-            String columnType,
             boolean isPolling,
-            Function<Long, String> function) {
+            String location) {
         StringBuilder sql = new StringBuilder(64);
         if (StringUtils.isNotEmpty(customSql)) {
             sql.append(JdbcUtil.TEMPORARY_TABLE_NAME).append(".");
@@ -953,28 +866,10 @@ public class JdbcInputFormat extends BaseRichInputFormat {
             // 轮询任务使用占位符
             sql.append("?");
         } else {
-            sql.append(buildLocation(columnType, location, function));
+            sql.append(location);
         }
 
         return sql.toString();
-    }
-
-    /**
-     * buildLocation
-     *
-     * @param columnType
-     * @param location
-     * @return
-     */
-    public String buildLocation(
-            String columnType, String location, Function<Long, String> function) {
-        if (ColumnType.isTimeType(columnType)) {
-            return function.apply(Long.parseLong(location));
-        } else if (ColumnType.isNumberType(columnType)) {
-            return location;
-        } else {
-            return "'" + location + "'";
-        }
     }
 
     /**
@@ -1012,5 +907,17 @@ public class JdbcInputFormat extends BaseRichInputFormat {
 
     public void setJdbcDialect(JdbcDialect jdbcDialect) {
         this.jdbcDialect = jdbcDialect;
+    }
+
+    public void setIncrementKeyUtil(KeyUtil<?, BigInteger> incrementKeyUtil) {
+        this.incrementKeyUtil = incrementKeyUtil;
+    }
+
+    public void setSplitKeyUtil(KeyUtil<?, BigInteger> splitKeyUtil) {
+        this.splitKeyUtil = splitKeyUtil;
+    }
+
+    public void setRestoreKeyUtil(KeyUtil<?, BigInteger> splitKeyUtil) {
+        this.restoreKeyUtil = splitKeyUtil;
     }
 }

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcInputFormatBuilder.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcInputFormatBuilder.java
@@ -21,6 +21,7 @@ package com.dtstack.chunjun.connector.jdbc.source;
 import com.dtstack.chunjun.conf.FieldConf;
 import com.dtstack.chunjun.connector.jdbc.conf.JdbcConf;
 import com.dtstack.chunjun.connector.jdbc.dialect.JdbcDialect;
+import com.dtstack.chunjun.connector.jdbc.util.key.KeyUtil;
 import com.dtstack.chunjun.constants.ConstantValue;
 import com.dtstack.chunjun.enums.ColumnType;
 import com.dtstack.chunjun.enums.Semantic;
@@ -28,6 +29,7 @@ import com.dtstack.chunjun.source.format.BaseRichInputFormatBuilder;
 
 import org.apache.commons.lang.StringUtils;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 
 /**
@@ -67,7 +69,6 @@ public class JdbcInputFormatBuilder extends BaseRichInputFormatBuilder<JdbcInput
             if (StringUtils.isBlank(conf.getIncreColumn())) {
                 sb.append("increColumn can't be empty when increment is true;\n");
             }
-            conf.setSplitPk(conf.getIncreColumn());
         }
 
         if (conf.getParallelism() > 1) {
@@ -105,5 +106,17 @@ public class JdbcInputFormatBuilder extends BaseRichInputFormatBuilder<JdbcInput
         if (sb.length() > 0) {
             throw new IllegalArgumentException(sb.toString());
         }
+    }
+
+    public void setIncrementKeyUtil(KeyUtil<?, BigInteger> incrementKeyUtil) {
+        format.setIncrementKeyUtil(incrementKeyUtil);
+    }
+
+    public void setSplitKeyUtil(KeyUtil<?, BigInteger> splitKeyUtil) {
+        format.setSplitKeyUtil(splitKeyUtil);
+    }
+
+    public void setRestoreKeyUtil(KeyUtil<?, BigInteger> splitKeyUtil) {
+        format.setRestoreKeyUtil(splitKeyUtil);
     }
 }

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcSourceFactory.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcSourceFactory.java
@@ -26,6 +26,9 @@ import com.dtstack.chunjun.connector.jdbc.conf.JdbcConf;
 import com.dtstack.chunjun.connector.jdbc.dialect.JdbcDialect;
 import com.dtstack.chunjun.connector.jdbc.exclusion.FieldNameExclusionStrategy;
 import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
+import com.dtstack.chunjun.connector.jdbc.util.key.KeyUtil;
+import com.dtstack.chunjun.connector.jdbc.util.key.NumericTypeUtil;
+import com.dtstack.chunjun.constants.ConstantValue;
 import com.dtstack.chunjun.converter.AbstractRowConverter;
 import com.dtstack.chunjun.converter.RawTypeConverter;
 import com.dtstack.chunjun.source.SourceFactory;
@@ -43,9 +46,12 @@ import com.google.gson.GsonBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
+import java.math.BigInteger;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * The Reader plugin for any database that can be connected via JDBC.
@@ -61,6 +67,10 @@ public abstract class JdbcSourceFactory extends SourceFactory {
     private static final int DEFAULT_CONNECTION_TIMEOUT = 600;
     protected JdbcConf jdbcConf;
     protected JdbcDialect jdbcDialect;
+
+    protected KeyUtil<?, BigInteger> incrementKeyUtil = new NumericTypeUtil();
+    protected KeyUtil<?, BigInteger> splitKeyUtil = new NumericTypeUtil();
+    protected KeyUtil<?, BigInteger> restoreKeyUtil = new NumericTypeUtil();
 
     public JdbcSourceFactory(
             SyncConf syncConf, StreamExecutionEnvironment env, JdbcDialect jdbcDialect) {
@@ -80,18 +90,7 @@ public abstract class JdbcSourceFactory extends SourceFactory {
 
         Properties properties = syncConf.getWriter().getProperties("properties", null);
         jdbcConf.setProperties(properties);
-        String name = syncConf.getRestore().getRestoreColumnName();
-        if (StringUtils.isNotBlank(name)) {
-            FieldConf fieldConf = FieldConf.getSameNameMetaColumn(jdbcConf.getColumn(), name);
-            if (fieldConf != null) {
-                jdbcConf.setRestoreColumn(name);
-                jdbcConf.setRestoreColumnIndex(fieldConf.getIndex());
-                jdbcConf.setRestoreColumnType(fieldConf.getType());
-            } else {
-                throw new IllegalArgumentException("unknown restore column name: " + name);
-            }
-        }
-        initIncrementConfig(jdbcConf);
+
         setDefaultSplitStrategy(jdbcConf);
         super.initCommonConf(jdbcConf);
         if (StringUtils.isBlank(jdbcConf.getCustomSql())) {
@@ -105,6 +104,11 @@ public abstract class JdbcSourceFactory extends SourceFactory {
 
     @Override
     public DataStream<RowData> createSource() {
+
+        initRestoreConfig();
+        initPollingConfig();
+        initSplitConfig();
+        initIncrementConfig();
         JdbcInputFormatBuilder builder = getBuilder();
 
         int fetchSize = jdbcConf.getFetchSize();
@@ -119,6 +123,9 @@ public abstract class JdbcSourceFactory extends SourceFactory {
 
         builder.setJdbcConf(jdbcConf);
         builder.setJdbcDialect(jdbcDialect);
+        builder.setRestoreKeyUtil(splitKeyUtil);
+        builder.setIncrementKeyUtil(incrementKeyUtil);
+        builder.setSplitKeyUtil(splitKeyUtil);
 
         AbstractRowConverter rowConverter = null;
         if (!useAbstractBaseColumn) {
@@ -152,12 +159,31 @@ public abstract class JdbcSourceFactory extends SourceFactory {
         }
     }
 
-    /**
-     * 初始化增量或间隔轮询任务配置
-     *
-     * @param jdbcConf jdbcConf
-     */
-    private void initIncrementConfig(JdbcConf jdbcConf) {
+    /** init restore info */
+    protected void initRestoreConfig() {
+        String name = syncConf.getRestore().getRestoreColumnName();
+        if (StringUtils.isNotBlank(name)) {
+            FieldConf fieldConf = FieldConf.getSameNameMetaColumn(jdbcConf.getColumn(), name);
+            if (fieldConf != null) {
+                jdbcConf.setRestoreColumn(name);
+                jdbcConf.setRestoreColumnIndex(fieldConf.getIndex());
+                jdbcConf.setRestoreColumnType(fieldConf.getType());
+                restoreKeyUtil = jdbcDialect.initKeyUtil(fieldConf.getName(), fieldConf.getType());
+            } else {
+                throw new IllegalArgumentException("unknown restore column name: " + name);
+            }
+        }
+    }
+
+    protected void initPollingConfig() {
+        // The Polling mode does not support range split now
+        if (jdbcConf.isPolling() && jdbcConf.getParallelism() > 1) {
+            jdbcConf.setSplitStrategy("mod");
+        }
+    }
+
+    /** 初始化增量或间隔轮询任务配置 */
+    private void initIncrementConfig() {
         String increColumn = jdbcConf.getIncreColumn();
 
         // 增量字段不为空，表示任务为增量或间隔轮询任务
@@ -207,6 +233,35 @@ public abstract class JdbcSourceFactory extends SourceFactory {
             jdbcConf.setRestoreColumn(name);
             jdbcConf.setRestoreColumnType(type);
             jdbcConf.setRestoreColumnIndex(index);
+
+            incrementKeyUtil = jdbcDialect.initKeyUtil(name, type);
+            restoreKeyUtil = incrementKeyUtil;
+            initStartLocation();
+
+            if (StringUtils.isBlank(jdbcConf.getSplitPk())) {
+                jdbcConf.setSplitPk(name);
+                splitKeyUtil = incrementKeyUtil;
+            }
+        }
+    }
+
+    public void initSplitConfig() {
+        String splitPk = jdbcConf.getSplitPk();
+        if (StringUtils.isNotBlank(splitPk)) {
+            jdbcConf.getColumn().stream()
+                    .filter(field -> field.getName().equals(splitPk))
+                    .findFirst()
+                    .ifPresent(
+                            field -> {
+                                if (StringUtils.isNotBlank(field.getValue())) {
+                                    throw new ChunJunRuntimeException(
+                                            "Constant columns are not supported as splitPk");
+                                } else {
+                                    splitKeyUtil =
+                                            jdbcDialect.initKeyUtil(
+                                                    field.getName(), field.getType());
+                                }
+                            });
         }
     }
 
@@ -224,5 +279,16 @@ public abstract class JdbcSourceFactory extends SourceFactory {
         if (StringUtils.isBlank(jdbcConf.getSchema())) {
             JdbcUtil.resetSchemaAndTable(jdbcConf, "\\\"", "\\\"");
         }
+    }
+
+    private void initStartLocation() {
+        String startLocation = jdbcConf.getStartLocation();
+        if (StringUtils.isNotBlank(jdbcConf.getStartLocation())) {
+            startLocation =
+                    Arrays.stream(startLocation.split(ConstantValue.COMMA_SYMBOL))
+                            .map(incrementKeyUtil::checkAndFormatLocationStr)
+                            .collect(Collectors.joining(ConstantValue.COMMA_SYMBOL));
+        }
+        jdbcConf.setStartLocation(startLocation);
     }
 }

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/DateTypeUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/DateTypeUtil.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.jdbc.util.key;
+
+import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigInteger;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/** @author liuliu 2022/6/22 */
+public class DateTypeUtil extends KeyUtil<Date, BigInteger> {
+
+    @Override
+    public Date getSqlValueFromRs(ResultSet rs, int index) throws SQLException {
+        return rs.getDate(index);
+    }
+
+    @Override
+    public Date getSqlValueFromRs(ResultSet rs, String columnName) throws SQLException {
+        return rs.getDate(columnName);
+    }
+
+    @Override
+    public void setPsWithSqlValue(PreparedStatement ps, int index, Date value) throws SQLException {
+        ps.setDate(index, value);
+    }
+
+    @Override
+    public void setPsWithLocationStr(PreparedStatement ps, int index, String value)
+            throws SQLException {
+        ps.setDate(index, new Date(Long.parseLong(value)));
+    }
+
+    @Override
+    public BigInteger transToLocationValueInternal(Object value) {
+        return BigInteger.valueOf(((Date) value).getTime());
+    }
+
+    @Override
+    public String transLocationStrToStatementValue(String locationStr) {
+        return String.format("'%s'", transLocationStrToSqlValue(locationStr));
+    }
+
+    @Override
+    public String transToStatementValueInternal(Object sqlValue) {
+        return String.format("'%s'", sqlValue);
+    }
+
+    @Override
+    public Date transLocationStrToSqlValue(String locationStr) {
+        return new Date(Long.parseLong(locationStr));
+    }
+
+    @Override
+    public BigInteger getNullDefaultLocationValue() {
+        return BigInteger.valueOf(Long.MIN_VALUE);
+    }
+
+    @Override
+    public String checkAndFormatLocationStr(String originLocationStr) {
+        if (!StringUtils.isNumeric(originLocationStr)) {
+            try {
+                return String.valueOf(Date.valueOf(originLocationStr).getTime());
+            } catch (Exception e) {
+                throw new ChunJunRuntimeException(
+                        String.format(
+                                "failed cast locationStr[%s] to Date,"
+                                        + "Please check location is a valid date string like yyyy-MM-dd",
+                                originLocationStr));
+            }
+        }
+        return originLocationStr;
+    }
+}

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/KeyUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/KeyUtil.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.jdbc.util.key;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author liuliu 2022/6/22
+ *     <p>Provides some methods that can be used to convert data in state, locationValue and
+ *     statementValue
+ *     <p>state: formatState
+ *     <p>locatinValue: startLocation/endLocation
+ *     <p>statementValue: Representation of data in SQL statements,example str -> 'str'
+ */
+public abstract class KeyUtil<T, F> implements Serializable {
+
+    public abstract T getSqlValueFromRs(ResultSet rs, int index) throws SQLException;
+
+    public abstract T getSqlValueFromRs(ResultSet rs, String column) throws SQLException;
+
+    public F getLocationValueFromRs(ResultSet rs, int index) throws SQLException {
+        Object object = rs.getObject(index);
+        if (object == null) {
+            return getNullDefaultLocationValue();
+        }
+        return transToLocationValue(getSqlValueFromRs(rs, index));
+    }
+
+    public F getLocationValueFromRs(ResultSet rs, String columnName) throws SQLException {
+        Object object = rs.getObject(columnName);
+        if (object == null) {
+            return getNullDefaultLocationValue();
+        }
+        return transToLocationValue(getSqlValueFromRs(rs, columnName));
+    };
+
+    public abstract void setPsWithSqlValue(PreparedStatement ps, int index, T value)
+            throws SQLException;
+
+    public abstract void setPsWithLocationStr(PreparedStatement ps, int index, String value)
+            throws SQLException;
+
+    public F transToLocationValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return transToLocationValueInternal(value);
+    }
+
+    public abstract F transToLocationValueInternal(Object value);
+
+    public abstract String transLocationStrToStatementValue(String locationStr);
+
+    public String transToStatementValue(Object sqlValue) {
+        if (sqlValue == null) {
+            return null;
+        }
+        return transToStatementValueInternal(sqlValue);
+    }
+
+    public abstract String transToStatementValueInternal(Object sqlValue);
+
+    public abstract T transLocationStrToSqlValue(String locationStr);
+
+    public abstract F getNullDefaultLocationValue();
+
+    public abstract String checkAndFormatLocationStr(String originLocationStr);
+}

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/NumericTypeUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/NumericTypeUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.jdbc.util.key;
+
+import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/** @author liuliu 2022/6/22 */
+public class NumericTypeUtil extends KeyUtil<Long, BigInteger> {
+
+    @Override
+    public Long getSqlValueFromRs(ResultSet rs, int index) throws SQLException {
+        return new BigDecimal(rs.getString(index)).toBigInteger().longValue();
+    }
+
+    @Override
+    public Long getSqlValueFromRs(ResultSet rs, String columnName) throws SQLException {
+        return new BigDecimal(rs.getString(columnName)).toBigInteger().longValue();
+    }
+
+    @Override
+    public void setPsWithSqlValue(PreparedStatement ps, int index, Long value) throws SQLException {
+        ps.setLong(index, value);
+    }
+
+    @Override
+    public void setPsWithLocationStr(PreparedStatement ps, int index, String value)
+            throws SQLException {
+        ps.setLong(index, Long.parseLong(value));
+    }
+
+    @Override
+    public BigInteger transToLocationValueInternal(Object value) {
+        return new BigDecimal(String.valueOf(value)).toBigInteger();
+    }
+
+    @Override
+    public String transLocationStrToStatementValue(String locationStr) {
+        return locationStr;
+    }
+
+    @Override
+    public String transToStatementValueInternal(Object sqlValue) {
+        return sqlValue.toString();
+    }
+
+    @Override
+    public Long transLocationStrToSqlValue(String locationStr) {
+        return Long.parseLong(locationStr);
+    }
+
+    @Override
+    public BigInteger getNullDefaultLocationValue() {
+        return BigInteger.valueOf(Long.MIN_VALUE);
+    }
+
+    @Override
+    public String checkAndFormatLocationStr(String originLocationStr) {
+        if (!StringUtils.isNumeric(originLocationStr)) {
+            throw new ChunJunRuntimeException(
+                    "Non-numeric location values are not supported when incrementColumnType is numeric");
+        }
+        return originLocationStr;
+    }
+}

--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/TimestampTypeUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/key/TimestampTypeUtil.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.jdbc.util.key;
+
+import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
+import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+/** @author liuliu 2022/6/22 */
+public class TimestampTypeUtil extends KeyUtil<Timestamp, BigInteger> {
+
+    @Override
+    public Timestamp getSqlValueFromRs(ResultSet rs, int index) throws SQLException {
+        return rs.getTimestamp(index);
+    }
+
+    @Override
+    public Timestamp getSqlValueFromRs(ResultSet rs, String columnName) throws SQLException {
+        return rs.getTimestamp(columnName);
+    }
+
+    @Override
+    public void setPsWithSqlValue(PreparedStatement ps, int index, Timestamp value)
+            throws SQLException {
+        ps.setTimestamp(index, value);
+    }
+
+    @Override
+    public void setPsWithLocationStr(PreparedStatement ps, int index, String value)
+            throws SQLException {
+        ps.setString(index, transLocationStrToTimeStr(value));
+    }
+
+    @Override
+    public BigInteger transToLocationValueInternal(Object value) {
+        return BigInteger.valueOf(((Timestamp) value).getTime());
+    }
+
+    @Override
+    public String transLocationStrToStatementValue(String locationStr) {
+        return String.format("'%s'", transLocationStrToTimeStr(locationStr));
+    }
+
+    @Override
+    public String transToStatementValueInternal(Object sqlValue) {
+        return transLocationStrToStatementValue(String.valueOf(((Timestamp) sqlValue).getTime()));
+    }
+
+    @Override
+    public Timestamp transLocationStrToSqlValue(String locationStr) {
+        return new Timestamp(Long.parseLong(locationStr));
+    }
+
+    @Override
+    public BigInteger getNullDefaultLocationValue() {
+        return BigInteger.valueOf(Long.MIN_VALUE);
+    }
+
+    @Override
+    public String checkAndFormatLocationStr(String originLocationStr) {
+        if (!StringUtils.isNumeric(originLocationStr)) {
+            try {
+                return String.valueOf(Timestamp.valueOf(originLocationStr).getTime());
+            } catch (Exception e) {
+                throw new ChunJunRuntimeException(
+                        String.format(
+                                "failed cast locationStr[%s] to Timestamp,"
+                                        + "Please check location is a valid timestamp string like yyyy-MM-dd HH:mm:ss",
+                                originLocationStr));
+            }
+        }
+        return originLocationStr;
+    }
+
+    public String transLocationStrToTimeStr(String timestampLongStr) {
+        long timestampLong = Long.parseLong(timestampLongStr);
+        String timestampStr;
+        Timestamp ts = new Timestamp(JdbcUtil.getMillis(timestampLong));
+        ts.setNanos(JdbcUtil.getNanos(timestampLong));
+        timestampStr = JdbcUtil.getNanosTimeStr(ts.toString());
+        return timestampStr.substring(0, 23);
+    }
+}

--- a/chunjun-connectors/chunjun-connector-mysql/src/main/java/com/dtstack/chunjun/connector/mysql/converter/MysqlRawTypeConverter.java
+++ b/chunjun-connectors/chunjun-connector-mysql/src/main/java/com/dtstack/chunjun/connector/mysql/converter/MysqlRawTypeConverter.java
@@ -42,6 +42,7 @@ public class MysqlRawTypeConverter {
             case "FLOAT":
             case "FLOAT UNSIGNED":
                 return DataTypes.FLOAT();
+            case "BIGINT UNSIGNED":
             case "DECIMAL":
             case "DECIMAL128":
             case "DECIMAL UNSIGNED":

--- a/chunjun-connectors/chunjun-connector-oracle/src/main/java/com/dtstack/chunjun/connector/oracle/source/OracleInputFormat.java
+++ b/chunjun-connectors/chunjun-connector-oracle/src/main/java/com/dtstack/chunjun/connector/oracle/source/OracleInputFormat.java
@@ -1,32 +1,10 @@
 package com.dtstack.chunjun.connector.oracle.source;
 
 import com.dtstack.chunjun.connector.jdbc.source.JdbcInputFormat;
-import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
-
-import java.sql.Timestamp;
 
 /**
  * company www.dtstack.com
  *
  * @author jier
  */
-public class OracleInputFormat extends JdbcInputFormat {
-
-    /**
-     * 构建时间边界字符串
-     *
-     * @param location 边界位置(起始/结束)
-     * @return
-     */
-    @Override
-    protected String getTimeStr(Long location) {
-        String timeStr;
-        Timestamp ts = new Timestamp(JdbcUtil.getMillis(location));
-        ts.setNanos(JdbcUtil.getNanos(location));
-        timeStr = JdbcUtil.getNanosTimeStr(ts.toString());
-        timeStr = timeStr.substring(0, 23);
-        timeStr = String.format("TO_TIMESTAMP('%s','yyyy-MM-dd HH24:mi:ss.FF6')", timeStr);
-
-        return timeStr;
-    }
-}
+public class OracleInputFormat extends JdbcInputFormat {}

--- a/chunjun-connectors/chunjun-connector-oracle/src/main/java/com/dtstack/chunjun/connector/oracle/util/increment/OracleTimestampTypeUtil.java
+++ b/chunjun-connectors/chunjun-connector-oracle/src/main/java/com/dtstack/chunjun/connector/oracle/util/increment/OracleTimestampTypeUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.oracle.util.increment;
+
+import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
+import com.dtstack.chunjun.connector.jdbc.util.key.TimestampTypeUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+/** @author liuliu 2022/6/22 */
+public class OracleTimestampTypeUtil extends TimestampTypeUtil {
+
+    @Override
+    public void setPsWithLocationStr(PreparedStatement ps, int index, String value)
+            throws SQLException {
+        ps.setString(index, transLocationStrToStatementValue(value));
+    }
+
+    @Override
+    public void setPsWithSqlValue(PreparedStatement ps, int index, Timestamp value)
+            throws SQLException {
+        ps.setString(index, transLocationStrToStatementValue(String.valueOf(value.getTime())));
+    }
+
+    @Override
+    public String transLocationStrToStatementValue(String locationStr) {
+        String timeStr;
+        Timestamp ts = new Timestamp(JdbcUtil.getMillis(Long.parseLong(locationStr)));
+        ts.setNanos(JdbcUtil.getNanos(Long.parseLong(locationStr)));
+        timeStr = JdbcUtil.getNanosTimeStr(ts.toString());
+        timeStr = timeStr.substring(0, 23);
+        return String.format("TO_TIMESTAMP('%s','yyyy-MM-dd HH24:mi:ss.FF6')", timeStr);
+    }
+}

--- a/chunjun-connectors/chunjun-connector-sqlserver/src/main/java/com/dtstack/chunjun/connector/sqlserver/source/SqlserverInputFormat.java
+++ b/chunjun-connectors/chunjun-connector-sqlserver/src/main/java/com/dtstack/chunjun/connector/sqlserver/source/SqlserverInputFormat.java
@@ -20,25 +20,14 @@ package com.dtstack.chunjun.connector.sqlserver.source;
 
 import com.dtstack.chunjun.connector.jdbc.source.JdbcInputFormat;
 import com.dtstack.chunjun.connector.jdbc.util.JdbcUtil;
-import com.dtstack.chunjun.enums.ColumnType;
 import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
-import com.dtstack.chunjun.throwable.ReadRecordException;
 import com.dtstack.chunjun.util.ExceptionUtil;
 
-import org.apache.flink.table.data.RowData;
-
-import org.apache.commons.lang3.StringUtils;
-
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.sql.Connection;
-import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.sql.Timestamp;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 /**
  * Company：www.dtstack.com
@@ -47,58 +36,6 @@ import java.util.function.Function;
  * @date 2021/5/19 13:57
  */
 public class SqlserverInputFormat extends JdbcInputFormat {
-
-    /**
-     * 构建边界位置sql
-     *
-     * @param incrementColType 增量字段类型
-     * @param incrementCol 增量字段名称
-     * @param location 边界位置(起始/结束)
-     * @param operator 判断符( >, >=, <)
-     * @return
-     */
-    @Override
-    protected String getLocationSql(
-            String incrementColType, String incrementCol, String location, String operator) {
-        String endTimeStr;
-        String endLocationSql;
-        boolean isTimeType =
-                ColumnType.isTimeType(incrementColType)
-                        || ColumnType.NVARCHAR.name().equals(incrementColType);
-        if (isTimeType) {
-            if (incrementColType.equalsIgnoreCase(ColumnType.TIMESTAMP.name())) {
-                endTimeStr = location;
-            } else {
-                endTimeStr = getTimeStr(Long.parseLong(location));
-            }
-            endLocationSql = incrementCol + operator + endTimeStr;
-        } else if (ColumnType.isNumberType(incrementColType)) {
-            endLocationSql = incrementCol + operator + location;
-        } else {
-            endTimeStr = String.format("'%s'", location);
-            endLocationSql = incrementCol + operator + endTimeStr;
-        }
-
-        return endLocationSql;
-    }
-
-    /**
-     * 构建时间边界字符串
-     *
-     * @param location 边界位置(起始/结束)
-     * @return
-     */
-    @Override
-    protected String getTimeStr(Long location) {
-        String timeStr;
-        Timestamp ts = new Timestamp(JdbcUtil.getMillis(location));
-        ts.setNanos(JdbcUtil.getNanos(location));
-        timeStr = JdbcUtil.getNanosTimeStr(ts.toString());
-        timeStr = timeStr.substring(0, 23);
-        timeStr = String.format("'%s'", timeStr);
-
-        return timeStr;
-    }
 
     @Override
     public boolean reachedEnd() {
@@ -127,13 +64,7 @@ public class SqlserverInputFormat extends JdbcInputFormat {
                     }
                     JdbcUtil.closeDbResources(resultSet, null, null, false);
                     // 此处endLocation理应不会为空
-                    String location;
-                    if (state instanceof byte[]) {
-                        location = new String((byte[]) state);
-                    } else {
-                        location = String.valueOf(state);
-                    }
-                    queryForPolling(location);
+                    queryForPolling(incrementKeyUtil.transToLocationValue(state).toString());
                     return false;
                 } catch (InterruptedException e) {
                     LOG.warn("interrupted while waiting for polling, e = {}", e);
@@ -149,105 +80,6 @@ public class SqlserverInputFormat extends JdbcInputFormat {
                 }
             }
             return true;
-        }
-    }
-
-    /**
-     * 增量轮询查询
-     *
-     * @param startLocation
-     * @throws SQLException
-     */
-    protected void queryForPolling(String startLocation) throws SQLException {
-        // 每隔五分钟打印一次，(当前时间 - 任务开始时间) % 300秒 <= 一个间隔轮询周期
-        if ((System.currentTimeMillis() - startTime) % 300000 <= jdbcConf.getPollingInterval()) {
-            LOG.info("polling startLocation = {}", startLocation);
-        } else {
-            LOG.debug("polling startLocation = {}", startLocation);
-        }
-
-        boolean isNumber = StringUtils.isNumeric(startLocation);
-        switch (type) {
-            case TIMESTAMP:
-                ps.setInt(1, Integer.parseInt(startLocation));
-                break;
-            case DATE:
-                Date date =
-                        isNumber
-                                ? new Date(Long.parseLong(startLocation))
-                                : Date.valueOf(startLocation);
-                ps.setDate(1, date);
-                break;
-            default:
-                if (isNumber) {
-                    ps.setLong(1, Long.parseLong(startLocation));
-                } else {
-                    ps.setString(1, startLocation);
-                }
-        }
-        resultSet = ps.executeQuery();
-        hasNext = resultSet.next();
-    }
-
-    @Override
-    public RowData nextRecordInternal(RowData rowData) throws ReadRecordException {
-        if (!hasNext) {
-            return null;
-        }
-        try {
-            @SuppressWarnings("unchecked")
-            RowData finalRowData = rowConverter.toInternal(resultSet);
-            if (needUpdateEndLocation) {
-                Object obj;
-                switch (type) {
-                    case DATETIME:
-                    case DATE:
-                        obj = resultSet.getTimestamp(jdbcConf.getIncreColumn()).getTime();
-                        break;
-                    case TIMESTAMP:
-                        obj =
-                                Integer.parseInt(
-                                        String.valueOf(
-                                                ByteBuffer.wrap(
-                                                                (byte[])
-                                                                        resultSet.getObject(
-                                                                                jdbcConf
-                                                                                                .getRestoreColumnIndex()
-                                                                                        + 1))
-                                                        .getLong()));
-                        break;
-                    default:
-                        obj = resultSet.getObject(jdbcConf.getIncreColumn());
-                }
-                String location = String.valueOf(obj);
-                endLocationAccumulator.add(new BigInteger(location));
-                LOG.debug("update endLocationAccumulator, current Location = {}", location);
-            }
-            if (jdbcConf.getRestoreColumnIndex() > -1) {
-                state = resultSet.getObject(jdbcConf.getRestoreColumnIndex() + 1);
-                if (state instanceof byte[]) {
-                    state =
-                            Integer.parseInt(
-                                    String.valueOf(
-                                            ByteBuffer.wrap(
-                                                            (byte[])
-                                                                    resultSet.getObject(
-                                                                            jdbcConf
-                                                                                            .getRestoreColumnIndex()
-                                                                                    + 1))
-                                                    .getLong()));
-                }
-            }
-            return finalRowData;
-        } catch (Exception se) {
-            throw new ReadRecordException("", se, 0, rowData);
-        } finally {
-            try {
-                hasNext = resultSet.next();
-            } catch (SQLException e) {
-                LOG.error("can not read next record", e);
-                hasNext = false;
-            }
         }
     }
 
@@ -279,19 +111,5 @@ public class SqlserverInputFormat extends JdbcInputFormat {
             return false;
         }
         return true;
-    }
-
-    public String buildLocation(
-            String columnType, String location, Function<Long, String> function) {
-        if (ColumnType.isTimeType(columnType)) {
-            if (ColumnType.TIMESTAMP.name().equalsIgnoreCase(columnType)) {
-                return location;
-            }
-            return function.apply(Long.parseLong(location));
-        } else if (ColumnType.isNumberType(columnType)) {
-            return location;
-        } else {
-            return "'" + location + "'";
-        }
     }
 }

--- a/chunjun-connectors/chunjun-connector-sqlserver/src/main/java/com/dtstack/chunjun/connector/sqlserver/util/SqlUtil.java
+++ b/chunjun-connectors/chunjun-connector-sqlserver/src/main/java/com/dtstack/chunjun/connector/sqlserver/util/SqlUtil.java
@@ -1,0 +1,37 @@
+package com.dtstack.chunjun.connector.sqlserver.util;
+
+import java.nio.ByteBuffer;
+
+public class SqlUtil {
+
+    public static long timestampBytesToLong(byte[] hexBytes) {
+        return ByteBuffer.wrap(hexBytes).getLong();
+    }
+
+    public static byte[] longToTimestampBytes(long longValue) {
+        byte[] timestampBytes = new byte[8];
+        for (int i = 7; i >= 0; i--) {
+            long bit1 = (longValue % 16);
+            longValue = longValue / 16;
+            long bit2 = (int) (longValue % 16);
+            longValue /= 16;
+            timestampBytes[i] = (byte) Integer.parseInt(transToBinaryString(bit1, bit2), 2);
+        }
+        return timestampBytes;
+    }
+
+    public static String transToBinaryString(long hexInt1, long hexInt2) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 4; i++) {
+            long bit = hexInt1 % 2;
+            hexInt1 /= 2;
+            builder.append(bit);
+        }
+        for (int i = 0; i < 4; i++) {
+            long bit = hexInt2 % 2;
+            hexInt2 /= 2;
+            builder.append(bit);
+        }
+        return builder.reverse().toString();
+    }
+}

--- a/chunjun-connectors/chunjun-connector-sqlserver/src/main/java/com/dtstack/chunjun/connector/sqlserver/util/increment/SqlserverTimestampTypeUtil.java
+++ b/chunjun-connectors/chunjun-connector-sqlserver/src/main/java/com/dtstack/chunjun/connector/sqlserver/util/increment/SqlserverTimestampTypeUtil.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.sqlserver.util.increment;
+
+import com.dtstack.chunjun.connector.jdbc.util.key.KeyUtil;
+import com.dtstack.chunjun.connector.sqlserver.util.SqlUtil;
+import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.math.BigInteger;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/** @author liuliu 2022/6/23 */
+public class SqlserverTimestampTypeUtil extends KeyUtil<byte[], BigInteger> {
+
+    @Override
+    public byte[] getSqlValueFromRs(ResultSet rs, int index) throws SQLException {
+        return rs.getBytes(index);
+    }
+
+    @Override
+    public byte[] getSqlValueFromRs(ResultSet rs, String column) throws SQLException {
+        return rs.getBytes(column);
+    }
+
+    @Override
+    public void setPsWithSqlValue(PreparedStatement ps, int index, byte[] value)
+            throws SQLException {
+        ps.setBytes(index, value);
+    }
+
+    @Override
+    public void setPsWithLocationStr(PreparedStatement ps, int index, String locationStr)
+            throws SQLException {
+        ps.setBytes(index, SqlUtil.longToTimestampBytes(Long.parseLong(locationStr)));
+    }
+
+    @Override
+    public BigInteger transToLocationValueInternal(Object value) {
+        return BigInteger.valueOf(SqlUtil.timestampBytesToLong((byte[]) value));
+    }
+
+    @Override
+    public String transLocationStrToStatementValue(String locationStr) {
+        return locationStr;
+    }
+
+    @Override
+    public String transToStatementValueInternal(Object sqlValue) {
+        return String.valueOf(SqlUtil.timestampBytesToLong((byte[]) sqlValue));
+    }
+
+    @Override
+    public byte[] transLocationStrToSqlValue(String locationStr) {
+        return SqlUtil.longToTimestampBytes(Long.parseLong(locationStr));
+    }
+
+    @Override
+    public BigInteger getNullDefaultLocationValue() {
+        return BigInteger.valueOf(Long.MIN_VALUE);
+    }
+
+    @Override
+    public String checkAndFormatLocationStr(String originLocationStr) {
+        if (!StringUtils.isNumeric(originLocationStr)) {
+            throw new ChunJunRuntimeException(
+                    String.format(
+                            "The Sqlserver timestamp type locationValue is expected to be of type long but it is %s",
+                            originLocationStr));
+        }
+        return originLocationStr;
+    }
+}

--- a/chunjun-e2e/src/test/java/com/dtstack/chunjun/connector/containers/emqx/EmqxContainer.java
+++ b/chunjun-e2e/src/test/java/com/dtstack/chunjun/connector/containers/emqx/EmqxContainer.java
@@ -31,9 +31,7 @@ import java.time.Duration;
 public class EmqxContainer extends GenericContainer<EmqxContainer> {
 
     private static final URL EMQX_DOCKERFILE =
-            EmqxContainer.class
-                    .getClassLoader()
-                    .getResource("docker/emqx/Dockerfile");
+            EmqxContainer.class.getClassLoader().getResource("docker/emqx/Dockerfile");
 
     public EmqxContainer(String imageName) throws URISyntaxException {
         super(
@@ -42,8 +40,7 @@ public class EmqxContainer extends GenericContainer<EmqxContainer> {
         waitingFor(
                 new WaitStrategy() {
                     @Override
-                    public void waitUntilReady(WaitStrategyTarget waitStrategyTarget) {
-                    }
+                    public void waitUntilReady(WaitStrategyTarget waitStrategyTarget) {}
 
                     @Override
                     public WaitStrategy withStartupTimeout(Duration startupTimeout) {
@@ -51,5 +48,4 @@ public class EmqxContainer extends GenericContainer<EmqxContainer> {
                     }
                 });
     }
-
 }

--- a/chunjun-e2e/src/test/java/com/dtstack/chunjun/connector/test/standalone/emqx/EmqxSyncE2eITCase.java
+++ b/chunjun-e2e/src/test/java/com/dtstack/chunjun/connector/test/standalone/emqx/EmqxSyncE2eITCase.java
@@ -52,7 +52,6 @@ public class EmqxSyncE2eITCase extends ChunjunFlinkStandaloneTestEnvironment {
                 .dependsOn(flinkStandaloneContainer);
     }
 
-
     @Before
     public void before() throws Exception {
         super.before();


### PR DESCRIPTION
…estoreColumn and splitPk

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->




## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->
1.Separate the relationship between incrementColumn with RestoreColumn and splitPk
2.Use keyUtil to handle data conversion between incrementColumn/splitPk/restoreColumn and StartLocation/EndLocation/state

## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
