### PR TITLE
[hotfix-#1256][kudu]Fix SQLMode datatype mapping

### DIFF
--- a/chunjun-connectors/chunjun-connector-kudu/src/main/java/com/dtstack/chunjun/connector/kudu/source/KuduInputFormatBuilder.java
+++ b/chunjun-connectors/chunjun-connector-kudu/src/main/java/com/dtstack/chunjun/connector/kudu/source/KuduInputFormatBuilder.java
@@ -50,7 +50,9 @@ public class KuduInputFormatBuilder extends BaseRichInputFormatBuilder<KuduInput
         StringBuilder sb = new StringBuilder(256);
 
         if (columns == null || columns.size() == 0) {
-            sb.append("Columns can not be empty.\n");
+            if (format.getRowConverter() == null) {
+                sb.append("At least one of the Column and rowConverter is not empty.\n");
+            }
         }
 
         if (sourceConf.getBatchSizeBytes() > ConstantValue.STORE_SIZE_G) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->
The SQL mode should directly use the rowType information in tableSchema, and no mapping is required
## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
