### PR TITLE
[hotfix][column]Fix the issue of timestampColumn convert to long error

### DIFF
--- a/chunjun-core/src/main/java/com/dtstack/chunjun/element/column/TimestampColumn.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/element/column/TimestampColumn.java
@@ -20,8 +20,6 @@ package com.dtstack.chunjun.element.column;
 import com.dtstack.chunjun.element.AbstractBaseColumn;
 import com.dtstack.chunjun.throwable.CastException;
 
-import org.apache.commons.net.ntp.TimeStamp;
-
 import java.math.BigDecimal;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -140,7 +138,7 @@ public class TimestampColumn extends AbstractBaseColumn {
         if (null == data) {
             return null;
         }
-        return new BigDecimal(((TimeStamp) data).getTime());
+        return new BigDecimal(((Timestamp) data).getTime());
     }
 
     @Override
@@ -148,7 +146,7 @@ public class TimestampColumn extends AbstractBaseColumn {
         if (null == data) {
             return null;
         }
-        return ((TimeStamp) data).getTime();
+        return ((Timestamp) data).getTime();
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/46181516/190568722-a1199d10-5be0-4364-86d5-4f811f3c41c1.png">
Type casting failed because of an import error
## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
