### PR TITLE
[hotfix-#987] [chunjun-connector-hdfs] fixed HdfsOrcOutputFormat can't get fullColumnType or fullColumnName from HdfsConf

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
@@ -83,6 +83,7 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
                     hdfsConf.getColumn().stream()
                             .map(FieldConf::getName)
                             .collect(Collectors.toList());
+            hdfsConf.setFullColumnName(fullColumnNameList);
         }
 
         if (CollectionUtils.isNotEmpty(hdfsConf.getFullColumnType())) {
@@ -92,6 +93,7 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
                     hdfsConf.getColumn().stream()
                             .map(FieldConf::getType)
                             .collect(Collectors.toList());
+            hdfsConf.setFullColumnName(fullColumnNameList);
         }
         compressType = getCompressType();
         super.initVariableFields();


### PR DESCRIPTION
This PR has been raised before this![https://github.com/DTStack/chunjun/pull/991]，but we didn't accept it，Is there something wrong ?If no you can choose one to accept，or what's our plan?

## Which issue you fix
#987

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
