### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/chunjun-connectors/chunjun-connector-kafka/pom.xml
+++ b/chunjun-connectors/chunjun-connector-kafka/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
 		<artifactId>chunjun-connectors</artifactId>
 		<groupId>com.dtstack.chunjun</groupId>
@@ -156,24 +154,16 @@
 						</goals>
 						<configuration>
 							<tasks>
-								<copy todir="${basedir}/../../${dist.dir}/connector/kafka"
-									  file="${basedir}/target/${project.artifactId}-${project.version}.jar"/>
-								<move file="${basedir}/../../${dist.dir}/connector/kafka/${project.artifactId}-${project.version}.jar"
-									  tofile="${basedir}/../../${dist.dir}/connector/kafka/${project.artifactId}.jar"/>
+								<copy todir="${basedir}/../../${dist.dir}/connector/kafka" file="${basedir}/target/${project.artifactId}-${project.version}.jar"/>
+								<move file="${basedir}/../../${dist.dir}/connector/kafka/${project.artifactId}-${project.version}.jar" tofile="${basedir}/../../${dist.dir}/connector/kafka/${project.artifactId}.jar"/>
 								<delete>
-									<fileset dir="${basedir}/../../${dist.dir}/connector/kafka/"
-											 includes="${project.artifactId}-*.jar"
-											 excludes="${project.artifactId}.jar"/>
+									<fileset dir="${basedir}/../../${dist.dir}/connector/kafka/" includes="${project.artifactId}-*.jar" excludes="${project.artifactId}.jar"/>
 								</delete>
 
-								<copy todir="${basedir}/../../${dist.dir}/connector/upsert-kafka"
-									  file="${basedir}/target/${project.artifactId}-${project.version}.jar"/>
-								<move file="${basedir}/../../${dist.dir}/connector/upsert-kafka/${project.artifactId}-${project.version}.jar"
-									  tofile="${basedir}/../../${dist.dir}/connector/upsert-kafka/${project.artifactId}.jar"/>
+								<copy todir="${basedir}/../../${dist.dir}/connector/upsert-kafka" file="${basedir}/target/${project.artifactId}-${project.version}.jar"/>
+								<move file="${basedir}/../../${dist.dir}/connector/upsert-kafka/${project.artifactId}-${project.version}.jar" tofile="${basedir}/../../${dist.dir}/connector/upsert-kafka/${project.artifactId}.jar"/>
 								<delete>
-									<fileset dir="${basedir}/../../${dist.dir}/connector/upsert-kafka/"
-											 includes="${project.artifactId}-*.jar"
-											 excludes="${project.artifactId}.jar"/>
+									<fileset dir="${basedir}/../../${dist.dir}/connector/upsert-kafka/" includes="${project.artifactId}-*.jar" excludes="${project.artifactId}.jar"/>
 								</delete>
 							</tasks>
 						</configuration>

--- a/chunjun-connectors/chunjun-connector-starrocks/pom.xml
+++ b/chunjun-connectors/chunjun-connector-starrocks/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
 		<artifactId>chunjun-connectors</artifactId>
 		<groupId>com.dtstack.chunjun</groupId>
@@ -29,7 +27,7 @@
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>fastjson</artifactId>
-			<version>1.2.79</version>
+			<version>1.2.83</version>
 		</dependency>
 
 		<dependency>
@@ -113,15 +111,10 @@
 						</goals>
 						<configuration>
 							<tasks>
-								<copy todir="${basedir}/../../${dist.dir}/connector/starrocks"
-									  file="${basedir}/target/${project.artifactId}-${project.version}.jar"/>
-								<move
-									file="${basedir}/../../${dist.dir}/connector/starrocks/${project.artifactId}-${project.version}.jar"
-									tofile="${basedir}/../../${dist.dir}/connector/starrocks/${project.artifactId}.jar"/>
+								<copy todir="${basedir}/../../${dist.dir}/connector/starrocks" file="${basedir}/target/${project.artifactId}-${project.version}.jar"/>
+								<move file="${basedir}/../../${dist.dir}/connector/starrocks/${project.artifactId}-${project.version}.jar" tofile="${basedir}/../../${dist.dir}/connector/starrocks/${project.artifactId}.jar"/>
 								<delete>
-									<fileset dir="${basedir}/../../${dist.dir}/connector/starrocks/"
-											 includes="${project.artifactId}-*.jar"
-											 excludes="${project.artifactId}.jar"/>
+									<fileset dir="${basedir}/../../${dist.dir}/connector/starrocks/" includes="${project.artifactId}-*.jar" excludes="${project.artifactId}.jar"/>
 								</delete>
 							</tasks>
 						</configuration>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.79
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.79 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS