### PR TITLE
fix(sec): upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive/pom.xml
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
-			<version>2.1.0</version>
+			<version>3.1.3</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-api</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 2.1.0
- [CVE-2018-11777](https://www.oscs1024.com/hd/CVE-2018-11777)


### What did I do？
Upgrade org.apache.hive:hive-exec from 2.1.0 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS