### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.dataformat:jackson-dataformat-cbor to 2.11.4

### DIFF
--- a/chunjun-connectors/chunjun-connector-s3/pom.xml
+++ b/chunjun-connectors/chunjun-connector-s3/pom.xml
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-cbor</artifactId>
-			<version>2.9.10</version>
+			<version>2.11.4</version>
 		</dependency>
 		<dependency>
 			<groupId>dk.brics.automaton</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.dataformat:jackson-dataformat-cbor 2.9.10
- [CVE-2020-28491](https://www.oscs1024.com/hd/CVE-2020-28491)


### What did I do？
Upgrade com.fasterxml.jackson.dataformat:jackson-dataformat-cbor from 2.9.10 to 2.11.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS