### PR TITLE
fix(sec): upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hdfs/pom.xml
@@ -13,7 +13,7 @@
 	<name>ChunJun : Connectors : HDFS</name>
 
 	<properties>
-		<hive.version>3.1.1</hive.version>
+		<hive.version>3.1.3</hive.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 3.1.1
- [CVE-2021-34538](https://www.oscs1024.com/hd/CVE-2021-34538)


### What did I do？
Upgrade org.apache.hive:hive-exec from 3.1.1 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS