### PR TITLE
fix(sec): upgrade com.jcraft:jsch to 0.1.54

### DIFF
--- a/chunjun-connectors/chunjun-connector-ftp/pom.xml
+++ b/chunjun-connectors/chunjun-connector-ftp/pom.xml
@@ -36,7 +36,7 @@ under the License.
 		<dependency>
 			<groupId>com.jcraft</groupId>
 			<artifactId>jsch</artifactId>
-			<version>0.1.51</version>
+			<version>0.1.54</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.jcraft:jsch 0.1.51
- [CVE-2016-5725](https://www.oscs1024.com/hd/CVE-2016-5725)


### What did I do？
Upgrade com.jcraft:jsch from 0.1.51 to 0.1.54 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS