### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/chunjun-connectors/chunjun-connector-socket/pom.xml
+++ b/chunjun-connectors/chunjun-connector-socket/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.0.23.Final</version>
+			<version>4.1.44.Final</version>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-all 4.0.23.Final
- [CVE-2019-16869](https://www.oscs1024.com/hd/CVE-2019-16869)


### What did I do？
Upgrade io.netty:netty-all from 4.0.23.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS