### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 42.4.1

### DIFF
--- a/chunjun-connectors/chunjun-connector-pgwal/pom.xml
+++ b/chunjun-connectors/chunjun-connector-pgwal/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.2.19</version>
+			<version>42.4.1</version>
 		</dependency>
 
 		<dependency>

--- a/chunjun-connectors/chunjun-connector-postgresql/pom.xml
+++ b/chunjun-connectors/chunjun-connector-postgresql/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.2.19</version>
+			<version>42.4.1</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-e2e/pom.xml
+++ b/chunjun-e2e/pom.xml
@@ -68,7 +68,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.2.19</version>
+			<version>42.4.1</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.2.19
- [CVE-2022-31197](https://www.oscs1024.com/hd/CVE-2022-31197)


### What did I do？
Upgrade org.postgresql:postgresql from 42.2.19 to 42.4.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS