### PR TITLE
fix(sec): upgrade org.apache.hive:hive-jdbc to 2.3.3

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive/pom.xml
@@ -134,7 +134,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-jdbc</artifactId>
-			<version>2.1.0</version>
+			<version>2.3.3</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-jdbc 2.1.0
- [CVE-2018-1282](https://www.oscs1024.com/hd/CVE-2018-1282)


### What did I do？
Upgrade org.apache.hive:hive-jdbc from 2.1.0 to 2.3.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS