### PR TITLE
fix(sec): upgrade org.apache.httpcomponents:httpclient to 4.5.13

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive3/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive3/pom.xml
@@ -368,7 +368,7 @@
 				</exclusion>
 			</exclusions>
 			<groupId>org.apache.httpcomponents</groupId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.httpcomponents:httpclient 4.5.2
- [CVE-2020-13956](https://www.oscs1024.com/hd/CVE-2020-13956)


### What did I do？
Upgrade org.apache.httpcomponents:httpclient from 4.5.2 to 4.5.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS