### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.2.4

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive3/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive3/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 		<hive.version>3.1.2</hive.version>
-		<hadoop3.version>3.1.4</hadoop3.version>
+		<hadoop3.version>3.2.4</hadoop3.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<flink.version>1.12.7</flink.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<prometheus.version>0.8.1</prometheus.version>
-		<hadoop.version>3.1.4</hadoop.version>
+		<hadoop.version>3.2.4</hadoop.version>
 		<http.version>4.5.3</http.version>
 		<chunjun.guava.version>27.0-jre</chunjun.guava.version>
 		<!-- fix CVE-2021-45105 -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-common 3.1.4
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 3.1.4 to 3.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS