### PR TITLE
fix(sec): upgrade org.apache.calcite:calcite-core to 1.32.0

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive3/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive3/pom.xml
@@ -331,7 +331,7 @@
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<version>1.31.0</version>
+			<version>1.32.0</version>
 		</dependency>
 		<dependency>
 			<artifactId>parquet-hadoop</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.calcite:calcite-core 1.31.0
- [CVE-2022-39135](https://www.oscs1024.com/hd/CVE-2022-39135)


### What did I do？
Upgrade org.apache.calcite:calcite-core from 1.31.0 to 1.32.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS