### PR TITLE
fix(sec): upgrade mysql:mysql-connector-java to 8.0.28

### DIFF
--- a/chunjun-connectors/chunjun-connector-mysql/pom.xml
+++ b/chunjun-connectors/chunjun-connector-mysql/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.46</version>
+            <version>8.0.28</version>
         </dependency>
     </dependencies>
 

--- a/chunjun-dirty/chunjun-dirty-mysql/pom.xml
+++ b/chunjun-dirty/chunjun-dirty-mysql/pom.xml
@@ -15,7 +15,7 @@
 	<properties>
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
-		<mysql.connector.version>5.1.46</mysql.connector.version>
+		<mysql.connector.version>8.0.28</mysql.connector.version>
 	</properties>
 
 	<dependencies>

--- a/chunjun-e2e/pom.xml
+++ b/chunjun-e2e/pom.xml
@@ -18,7 +18,7 @@
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 		<testcontainers.version>1.15.3</testcontainers.version>
-		<mysql.driver.version>5.1.46</mysql.driver.version>
+		<mysql.driver.version>8.0.28</mysql.driver.version>
 	</properties>
 
 	<dependencies>

--- a/chunjun-metrics/chunjun-metrics-mysql/pom.xml
+++ b/chunjun-metrics/chunjun-metrics-mysql/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.46</version>
+			<version>8.0.28</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-restore/chunjun-restore-mysql/pom.xml
+++ b/chunjun-restore/chunjun-restore-mysql/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
-		<mysql.version>5.1.46</mysql.version>
+		<mysql.version>8.0.28</mysql.version>
 		<sharding.jdbc.version>4.1.1</sharding.jdbc.version>
 		<druid.version>1.2.8</druid.version>
 	</properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in mysql:mysql-connector-java 5.1.46
- [CVE-2022-21363](https://www.oscs1024.com/hd/CVE-2022-21363)


### What did I do？
Upgrade mysql:mysql-connector-java from 5.1.46 to 8.0.28 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS