### PR TITLE
feat-support multiple params with comma after -p 

### DIFF
--- a/chunjun-core/src/main/java/com/dtstack/chunjun/constants/ConstantValue.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/constants/ConstantValue.java
@@ -28,6 +28,8 @@ public class ConstantValue {
     public static final String SINGLE_QUOTE_MARK_SYMBOL = "'";
     public static final String DOUBLE_QUOTE_MARK_SYMBOL = "\"";
     public static final String COMMA_SYMBOL = ",";
+    public static final String PARAMS_SEP = "-M";
+    public static final String EMPTY_STR = "";
     public static final String SEMICOLON_SYMBOL = ";";
 
     public static final String SINGLE_SLASH_SYMBOL = "/";

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/util/JobUtil.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/util/JobUtil.java
@@ -48,13 +48,29 @@ public class JobUtil {
         return json;
     }
 
-    /** 将命令行中的修改命令转化为HashMap保存 */
+    /**
+     * @param command
+     * @return HashMap
+     * @description: convert params after '-p' in shell to hashmap
+     */
     public static HashMap<String, String> CommandTransform(String command) {
         HashMap<String, String> parameter = new HashMap<>();
         String[] split = StringUtils.split(command, ConstantValue.COMMA_SYMBOL);
-        for (String item : split) {
-            String[] temp = item.split(ConstantValue.EQUAL_SYMBOL);
-            parameter.put(temp[0].trim(), temp[1].trim());
+        for (int i = 0; i < split.length; i++) {
+            String[] params = split[i].split(ConstantValue.EQUAL_SYMBOL);
+            if (params[0].trim().startsWith(ConstantValue.PARAMS_SEP)) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(params[1]);
+                while (i + 1 < split.length && !split[i + 1].contains(ConstantValue.EQUAL_SYMBOL)) {
+                    sb.append(ConstantValue.COMMA_SYMBOL + split[i + 1]);
+                    i++;
+                }
+                String key =
+                        params[0].trim().replace(ConstantValue.PARAMS_SEP, ConstantValue.EMPTY_STR);
+                parameter.put(key, sb.toString());
+            } else {
+                parameter.put(params[0].trim(), params[1].trim());
+            }
         }
         return parameter;
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
support multiple params after -p ，If we want set multiple params with comma,we can set like this:
```
-p -Mbootstrap=host1:9092,host2:9092
```

## Which issue you fix
#1388

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
