### PR TITLE
fix BUG #1398,fix bsh,xml-resolver default version cannot access

### DIFF
--- a/bin/submit.sh
+++ b/bin/submit.sh
@@ -46,9 +46,9 @@ fi
 # 1.In yarn-session case, JAR_DIR can not be found
 # 2.In other cases, JAR_DIR can be found
 if [ $CHUNJUN_DEPLOY_MODE -eq 1 ]; then
-  JAR_DIR=$CHUNJUN_HOME/lib/*
+  JAR_DIR=$CHUNJUN_HOME/lib/chunjun-clients.jar:$CHUNJUN_HOME/lib/*
 else
-  JAR_DIR=$CHUNJUN_HOME/../lib/*
+  JAR_DIR=$CHUNJUN_HOME/../lib/chunjun-clients.jar:$CHUNJUN_HOME/../lib/*
 fi
 
 CLASS_NAME=com.dtstack.chunjun.client.Launcher

--- a/chunjun-assembly/pom.xml
+++ b/chunjun-assembly/pom.xml
@@ -33,14 +33,49 @@
 	<packaging>pom</packaging>
 	<name>ChunJun : Assembly</name>
 
-
 	<properties>
 		<skipTests>true</skipTests>
+		<!--version same as flink-1.12.7-bin-scala_2.12.tgz/lib/log4j-* -->
+		<log4j2.version>2.16.0</log4j2.version>
 		<main.basedir>${project.parent.basedir}</main.basedir>
 		<sbt.project.name>assembly</sbt.project.name>
 		<build.testJarPhase>none</build.testJarPhase>
 		<build.copyDependenciesPhase>package</build.copyDependenciesPhase>
 	</properties>
+
+	<dependencies>
+		<!--add log4j-*jars to package to tar.gz/lib -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>${log4j2.version}</version>
+			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>slf4j-api</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/chunjun-assembly/src/main/assembly/assembly.xml
+++ b/chunjun-assembly/src/main/assembly/assembly.xml
@@ -59,8 +59,12 @@
 			<outputDirectory>lib</outputDirectory>
 			<useTransitiveDependencies>true</useTransitiveDependencies>
 			<unpack>false</unpack>
-			<scope>package</scope>
+			<scope>provided</scope>
 			<useProjectArtifact>false</useProjectArtifact>
+			<!-- only include log4j-*.jars -->
+			<includes>
+				<include>org.apache.logging.log4j:*</include>
+			</includes>
 		</dependencySet>
 	</dependencySets>
 </assembly>

--- a/chunjun-clients/pom.xml
+++ b/chunjun-clients/pom.xml
@@ -233,6 +233,17 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+							<!--exclude all log api and impls -->
+							<artifactSet>
+								<excludes>
+									<exclude>org.slf4j:*</exclude>
+									<exclude>org.apache.logging.log4j:*</exclude>
+									<exclude>ch.qos.logback:*</exclude>
+									<exclude>ch.qos.reload4j:*</exclude>
+									<exclude>commons-logging:*</exclude>
+									<exclude>log4j:log4j</exclude>
+								</excludes>
+							</artifactSet>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<transformers>
 

--- a/chunjun-connectors/chunjun-connector-hdfs/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hdfs/pom.xml
@@ -228,10 +228,14 @@
 						</goals>
 						<configuration>
 							<artifactSet>
+								<!--exclude all log api and impls -->
 								<excludes>
-									<exclude>org.slf4j:slf4j-api</exclude>
-									<exclude>log4j:log4j</exclude>
+									<exclude>org.slf4j:*</exclude>
+									<exclude>org.apache.logging.log4j:*</exclude>
 									<exclude>ch.qos.logback:*</exclude>
+									<exclude>ch.qos.reload4j:*</exclude>
+									<exclude>commons-logging:*</exclude>
+									<exclude>log4j:log4j</exclude>
 								</excludes>
 							</artifactSet>
 							<filters>

--- a/chunjun-connectors/chunjun-connector-hive/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive/pom.xml
@@ -285,6 +285,17 @@
 						</goals>
 						<configuration>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
+							<!--exclude all log api and impls -->
+							<artifactSet>
+								<excludes>
+									<exclude>org.slf4j:*</exclude>
+									<exclude>org.apache.logging.log4j:*</exclude>
+									<exclude>ch.qos.logback:*</exclude>
+									<exclude>ch.qos.reload4j:*</exclude>
+									<exclude>commons-logging:*</exclude>
+									<exclude>log4j:log4j</exclude>
+								</excludes>
+							</artifactSet>
 							<filters>
 								<filter>
 									<artifact>*:*</artifact>

--- a/chunjun-core/pom.xml
+++ b/chunjun-core/pom.xml
@@ -451,10 +451,10 @@
                             </transformers>
                             <artifactSet>
                                 <includes>
+									<!--only include slf4j api , exclude other log api & impls -->
+									<include>org.slf4j:slf4j-api</include>
                                     <include>com.google.guava:*</include>
                                     <include>com.google.code.gson:*</include>
-                                    <include>ch.qos.logback:*</include>
-                                    <include>org.slf4j:*</include>
                                     <include>org.apache.httpcomponents:*</include>
                                     <include>io.prometheus:*</include>
                                     <include>org.apache.avro:*</include>
@@ -508,10 +508,10 @@
 							</transformers>
 							<artifactSet>
 								<includes>
+									<!--only include slf4j api -->
+									<include>org.slf4j:slf4j-api</include>
 									<include>com.google.guava:*</include>
 									<include>com.google.code.gson:*</include>
-									<include>ch.qos.logback:*</include>
-									<include>org.slf4j:*</include>
 									<include>org.apache.httpcomponents:*</include>
 									<include>io.prometheus:*</include>
 									<include>org.apache.avro:*</include>

--- a/chunjun-ddl/chunjun-ddl-mysql/pom.xml
+++ b/chunjun-ddl/chunjun-ddl-mysql/pom.xml
@@ -194,9 +194,13 @@
 						<configuration>
 							<artifactSet>
 								<excludes>
-									<exclude>org.slf4j:slf4j-api</exclude>
-									<exclude>log4j:log4j</exclude>
+									<!--exclude all log api and impls -->
+									<exclude>org.slf4j:*</exclude>
+									<exclude>org.apache.logging.log4j:*</exclude>
 									<exclude>ch.qos.logback:*</exclude>
+									<exclude>ch.qos.reload4j:*</exclude>
+									<exclude>commons-logging:*</exclude>
+									<exclude>log4j:log4j</exclude>
 								</excludes>
 							</artifactSet>
 							<filters>

--- a/chunjun-ddl/chunjun-ddl-mysql/pom.xml
+++ b/chunjun-ddl/chunjun-ddl-mysql/pom.xml
@@ -130,6 +130,16 @@
 						<artifactId>freemarker</artifactId>
 						<version>2.3.28</version>
 					</dependency>
+					<dependency>
+						<groupId>org.beanshell</groupId>
+						<artifactId>bsh</artifactId>
+						<version>2.0b5</version>
+					</dependency>
+					<dependency>
+						<groupId>xml-resolver</groupId>
+						<artifactId>xml-resolver</artifactId>
+						<version>1.2</version>
+					</dependency>
 				</dependencies>
 				<executions>
 					<execution>

--- a/chunjun-restore/chunjun-restore-mysql/pom.xml
+++ b/chunjun-restore/chunjun-restore-mysql/pom.xml
@@ -83,9 +83,13 @@
 						<configuration>
 							<artifactSet>
 								<excludes>
-									<exclude>org.slf4j:slf4j-api</exclude>
-									<exclude>log4j:log4j</exclude>
+									<!--exclude all log api and impls -->
+									<exclude>org.slf4j:*</exclude>
+									<exclude>org.apache.logging.log4j:*</exclude>
 									<exclude>ch.qos.logback:*</exclude>
+									<exclude>ch.qos.reload4j:*</exclude>
+									<exclude>commons-logging:*</exclude>
+									<exclude>log4j:log4j</exclude>
 								</excludes>
 							</artifactSet>
 							<filters>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
bsh,xml-resolver 的默认版本无法直接访问到，更新版本到可访问版本。本地maven 打包测试通过。

## Which issue you fix
Fixes # (1398).

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [x] I have performed a self-review of my own code.
- [] I have commented my code, particularly in hard-to-understand areas.
- [] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
