### PR TITLE
[hotfix][hdfs and oraclelogminer] Solved the problem of splitting columns and handling null values in hdfs components

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
@@ -108,6 +108,23 @@ public class HdfsTextColumnConverter
     }
 
     @Override
+    protected IDeserializationConverter wrapIntoNullableInternalConverter(
+            IDeserializationConverter IDeserializationConverter) {
+        return val -> {
+            if (val == null || "".equals(val)) {
+                return null;
+            } else {
+                try {
+                    return IDeserializationConverter.deserialize(val);
+                } catch (Exception e) {
+                    LOG.error("value [{}] convent failed ", val);
+                    throw e;
+                }
+            }
+        };
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     protected ISerializationConverter<String[]> wrapIntoNullableExternalConverter(
             ISerializationConverter serializationConverter, String type) {

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/source/HdfsTextInputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/source/HdfsTextInputFormat.java
@@ -123,7 +123,8 @@ public class HdfsTextInputFormat extends BaseHdfsInputFormat {
                             ((Text) value).getLength(),
                             hdfsConf.getEncoding());
             String[] fields =
-                    StringUtils.splitPreserveAllTokens(line, hdfsConf.getFieldDelimiter());
+                    StringUtils.splitByWholeSeparatorPreserveAllTokens(
+                            line, hdfsConf.getFieldDelimiter());
 
             List<FieldConf> fieldConfList = hdfsConf.getColumn();
             GenericRowData genericRowData;

--- a/chunjun-connectors/chunjun-connector-oraclelogminer/src/main/java/com/dtstack/chunjun/connector/oraclelogminer/listener/LogMinerListener.java
+++ b/chunjun-connectors/chunjun-connector-oraclelogminer/src/main/java/com/dtstack/chunjun/connector/oraclelogminer/listener/LogMinerListener.java
@@ -524,7 +524,9 @@ public class LogMinerListener implements Runnable {
             }
 
             /* generate create table ddl */
-            initialTableStruct(conn);
+            if (logMinerConf.isInitialTableStructure()) {
+                initialTableStruct(conn);
+            }
 
             /* release lock */
             stmt.execute(SqlUtil.releaseTableLock());


### PR DESCRIPTION
1. hdfs connector：
1.1 make  column converter can dealing with null value of column correctly 
1.2 make the inputformatter can split correctly text row by seperate operator that consists of multiple characters

2.oracle log miner connector：
2.1 when setting the enableFetchAll to true , the job would generate table ddl statement no mater whether the initialTableStructure parameter is set to true. Now add a if statement for controlling this feature.