### PR TITLE
[hotfix][hdfs]when writing to hdfs, null value is set to '\N'

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
@@ -130,7 +130,7 @@ public class HdfsTextColumnConverter
             ISerializationConverter serializationConverter, String type) {
         return (rowData, index, data) -> {
             if (rowData == null || rowData.isNullAt(index)) {
-                data[index] = null;
+                data[index] = "\\N";
             } else {
                 serializationConverter.serialize(rowData, index, data);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<flinkcdc.version>1.3.0</flinkcdc.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<prometheus.version>0.8.1</prometheus.version>
-		<hadoop.version>3.1.4</hadoop.version>
+		<hadoop.version>3.0.0-cdh6.3.2</hadoop.version>
 		<http.version>4.5.3</http.version>
 		<chunjun.guava.version>27.0-jre</chunjun.guava.version>
 		<!-- fix CVE-2021-45105 -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<flinkcdc.version>1.3.0</flinkcdc.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<prometheus.version>0.8.1</prometheus.version>
-		<hadoop.version>3.0.0-cdh6.3.2</hadoop.version>
+		<hadoop.version>3.1.4</hadoop.version>
 		<http.version>4.5.3</http.version>
 		<chunjun.guava.version>27.0-jre</chunjun.guava.version>
 		<!-- fix CVE-2021-45105 -->


### PR DESCRIPTION
fix the issue: The hdfs connector cannot read correctly from the hfds files which generated by the hdfs connector itself.
When hdfs connector writing data to hdfs, null value of a  column is set as a member of a  String array that is a data row`s output, eg, data[0] = null,  that results in "null" string value would be written into the hdfs text files.

solution: 
null value is set to '\N' for hive specification so that hdfs connector can read from the output.