### PR TITLE
[hotfix][hdfs]when writing to hfds,null value is set to '\N'

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
@@ -130,7 +130,7 @@ public class HdfsTextColumnConverter
             ISerializationConverter serializationConverter, String type) {
         return (rowData, index, data) -> {
             if (rowData == null || rowData.isNullAt(index)) {
-                data[index] = null;
+                data[index] = "\\N";
             } else {
                 serializationConverter.serialize(rowData, index, data);
             }


### PR DESCRIPTION
fix the issue: The hdfs connector cannot read correctly from the hfds files which generated by the hdfs connector itself.
When hdfs connector writing data to hdfs, null value of a  column is set as a member of a  String array that is a data row`s output, eg, data[0] = null,  that results in "null" string value would be written into the hdfs text files.

solution: 
null value is set to '\N' for hive specification so that hdfs connector can read from the output.