### PR TITLE
Fix:mysql-cdc can't run in sql mode

### DIFF
--- a/chunjun-connectors/chunjun-connector-mysqlcdc/pom.xml
+++ b/chunjun-connectors/chunjun-connector-mysqlcdc/pom.xml
@@ -91,6 +91,9 @@
 									</excludes>
 								</filter>
 							</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+							</transformers>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
com.ververica.cdc.connectors.mysql.table.MySqlTableSourceFactory not merge in META-INF/services/org.apache.flink.table.factories.Factory when maven package

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

## Which issue you fix
Fixes # (issue).

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
