### PR TITLE
[fix-##1451] add column replace for hbase column

### DIFF
--- a/chunjun-connectors/chunjun-connector-hbase-base/src/main/java/com/dtstack/chunjun/connector/hbase/FunctionParser.java
+++ b/chunjun-connectors/chunjun-connector-hbase-base/src/main/java/com/dtstack/chunjun/connector/hbase/FunctionParser.java
@@ -172,4 +172,15 @@ public class FunctionParser {
 
         return express;
     }
+
+    public static List<String> getRegexColumnName(String qualifier) {
+        Matcher matcher = COL_PATTERN.matcher(qualifier);
+        ArrayList<String> columnQualifier = new ArrayList<>();
+        while (matcher.find()) {
+            String columnGroup = matcher.group();
+            String column = columnGroup.substring(2, columnGroup.length() - 1);
+            columnQualifier.add(column);
+        }
+        return columnQualifier;
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
As we know,we can use 'rowkeyExpress' in hbasecolumn. and chunjun will replace the value in "$()",this pr can support column field also has that function.

我们知道在hbase-connector中可以使用'rowkeyExpress'当做主键表达式，chunjun会用字段值替换在"$()"中的字段名称，这个pr可以支持 列字段 同样有这个功能。

。。。
"rowkeyExpress": "$(rowkey)",
"column": [
{"type": "string","name":"v:cid"},
{"type": "string","name":"rowkey"},
{"type": "string","name":"v:c_30_i_$(cid)"},
{"type": "string","name":"v:c_30_c_$(cid)"},
{"type": "string","name":"v:c_30_r_$(cid)"}
]
。。。

## Which issue you fix
#1451 

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
