### PR TITLE
[BugFix][Postgres][#1463] The cast is bad, only when 'rowConverter' instance of the 'JdbcColumnConverter' should cast.

### DIFF
--- a/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/sink/PostgresOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-postgresql/src/main/java/com/dtstack/chunjun/connector/postgresql/sink/PostgresOutputFormat.java
@@ -88,10 +88,12 @@ public class PostgresOutputFormat extends JdbcOutputFormat {
                 LOG.info("write sql:{}", copySql);
             }
             checkUpsert();
-            if (jdbcDialect.dialectName().equals("PostgreSQL")) {
-                ((PostgresqlColumnConverter) rowConverter).setConnection((BaseConnection) dbConn);
+            if (rowConverter instanceof JdbcColumnConverter) {
+                if (jdbcDialect.dialectName().equals("PostgresSQL")) {
+                    ((PostgresqlColumnConverter) rowConverter).setConnection((BaseConnection) dbConn);
+                }
+                ((PostgresqlColumnConverter) rowConverter).setFieldTypeList(columnTypeList);
             }
-            ((PostgresqlColumnConverter) rowConverter).setFieldTypeList(columnTypeList);
         } catch (SQLException sqe) {
             throw new IllegalArgumentException("checkUpsert() failed.", sqe);
         }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

The cast is bad, only when 'rowConverter' instance of the 'JdbcColumnConverter' should cast.

## Which issue you fix
Fixes # (1463).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
