### PR TITLE
[hotfix][http]Solve the separator and cause the dynamic table to fail…

### DIFF
--- a/chunjun-connectors/chunjun-connector-http/src/main/java/com/dtstack/chunjun/connector/http/converter/HttpRowConverter.java
+++ b/chunjun-connectors/chunjun-connector-http/src/main/java/com/dtstack/chunjun/connector/http/converter/HttpRowConverter.java
@@ -74,9 +74,7 @@ public class HttpRowConverter
         GenericRowData genericRowData = new GenericRowData(rowType.getFieldCount());
         List<String> columns = rowType.getFieldNames();
         for (int pos = 0; pos < columns.size(); pos++) {
-            Object value =
-                    MapUtil.getValueByKey(
-                            result, columns.get(pos), httpRestConfig.getFieldDelimiter());
+            Object value = MapUtil.getValueByKey(result, columns.get(pos), "");
             if (value instanceof LinkedTreeMap) {
                 value = value.toString();
             }

--- a/chunjun-examples/sql/http/http_stream.sql
+++ b/chunjun-examples/sql/http/http_stream.sql
@@ -3,10 +3,10 @@ CREATE TABLE source
     id             int,
     name           varchar
 ) WITH (
-      'connector' = 'restapi-x'
+      'connector' = 'http-x'
       ,'url' = 'http://dev.insight.dtstack.cn/api/streamapp/service/streamCatalogue/getCatalogue'
       ,'intervalTime'= '3000'
-       ,'requestMode'='post'
+       ,'method'='post'
         ,'decode'= 'json'
         ,'body'= '[
               {
@@ -37,11 +37,11 @@ CREATE TABLE source
             ]'
             ,'column'='[
               {
-                "name": "data.id",
+                "name": "id",
                 "type": "int"
               },
               {
-                "name": "data.name",
+                "name": "name",
                 "type": "string"
               }
             ]'


### PR DESCRIPTION
Solve the separator and cause the dynamic table to fail to get the corresponding value and throw an exception and modified the sample file.
```
CREATE TABLE source
(
    id             int,
    name           varchar,
    `person.name`  varchar
) WITH (
      'connector' = 'http-x'
      ,'url' = 'http://xxxx'
      ,'intervalTime'= '3000'
       ,'method'='post'

        ,'decode'= 'json'
            ,'column'='[
              {
                "name": "id",
                "type": "int"
              },
              {
                "name": "name",
                "type": "string"
              },
              {
                "name": "person.name",
                "type": "string"
              }
            ]'
      );

CREATE TABLE sink
(
    id             int,
    name      varchar,
    name1      varchar
) WITH (
      'connector' = 'stream-x'
      );

insert into sink
select *
from source u;

```
http result
```
{"data":[{"id":1,"name":"张三","person":{"name":"张三"}}],"name":"2"}
```
Before fix
![image](https://user-images.githubusercontent.com/13957201/219637257-8641c7ce-4379-42e5-8682-e68c5b5d0ab0.png)
After fix
![image](https://user-images.githubusercontent.com/13957201/219637723-0695618a-c6ce-4b3c-b1cb-dbaf8c76ab8b.png)

