### PR TITLE
[hotfix-#1518][mongodb] fix mongodb read data not support objectId type

### DIFF
--- a/chunjun-connectors/chunjun-connector-http/src/main/java/com/dtstack/chunjun/connector/http/converter/HttpColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-http/src/main/java/com/dtstack/chunjun/connector/http/converter/HttpColumnConverter.java
@@ -52,7 +52,7 @@ public class HttpColumnConverter
 
     public HttpColumnConverter(HttpRestConfig httpRestConfig) {
         this.httpRestConfig = httpRestConfig;
-        this.commonConf = httpRestConfig;
+        this.commonConfig = httpRestConfig;
 
         // Only json need to extract the fields
         if (StringUtils.isNotBlank((httpRestConfig.getFields()))) {

--- a/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/converter/MongodbColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/converter/MongodbColumnConverter.java
@@ -28,6 +28,7 @@ import com.dtstack.chunjun.element.column.BooleanColumn;
 import com.dtstack.chunjun.element.column.BytesColumn;
 import com.dtstack.chunjun.element.column.StringColumn;
 import com.dtstack.chunjun.element.column.TimestampColumn;
+import com.dtstack.chunjun.util.GsonUtil;
 
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -43,6 +44,7 @@ import java.sql.Date;
 import java.sql.Time;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public class MongodbColumnConverter
         extends AbstractRowConverter<Document, Document, Document, LogicalType> {
@@ -134,7 +136,13 @@ public class MongodbColumnConverter
                 return val -> new BigDecimalColumn(((Decimal128) val).bigDecimalValue());
             case CHAR:
             case VARCHAR:
-                return val -> new StringColumn((String) val);
+                return val -> {
+                    if (val instanceof List || val instanceof Map) {
+                        return new StringColumn(GsonUtil.GSON.toJson(val));
+                    } else {
+                        return new StringColumn(val.toString());
+                    }
+                };
             case INTERVAL_YEAR_MONTH:
             case DATE:
             case TIME_WITHOUT_TIME_ZONE:


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->
fix mongodb read data not support objectId type
## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
