### PR TITLE
[Improvement][assembly] the chunjun-clients.jar cannot be found after packaging

### DIFF
--- a/chunjun-assembly/src/main/assembly/assembly.xml
+++ b/chunjun-assembly/src/main/assembly/assembly.xml
@@ -52,6 +52,13 @@
 			</directory>
 			<outputDirectory>lib</outputDirectory>
 		</fileSet>
+		<fileSet>
+			<directory>${project.parent.basedir}/chunjun-clients/target</directory>
+			<outputDirectory>lib</outputDirectory>
+			<includes>
+				<include>chunjun-clients.jar</include>
+			</includes>
+		</fileSet>
 	</fileSets>
 
 	<dependencySets>
@@ -61,6 +68,10 @@
 			<unpack>false</unpack>
 			<scope>provided</scope>
 			<useProjectArtifact>false</useProjectArtifact>
+			<!-- only include log4j-*.jars -->
+			<includes>
+				<include>org.apache.logging.log4j:*</include>
+			</includes>
 		</dependencySet>
 	</dependencySets>
 </assembly>

--- a/chunjun-assembly/src/main/assembly/assembly.xml
+++ b/chunjun-assembly/src/main/assembly/assembly.xml
@@ -61,10 +61,6 @@
 			<unpack>false</unpack>
 			<scope>provided</scope>
 			<useProjectArtifact>false</useProjectArtifact>
-			<!-- only include log4j-*.jars -->
-			<includes>
-				<include>org.apache.logging.log4j:*</include>
-			</includes>
 		</dependencySet>
 	</dependencySets>
 </assembly>


### PR DESCRIPTION
…aging

the chunjun-clients.jar cannot be found after packaging
[add][assembly]
```
<fileSet>
  <directory>${project.parent.basedir}/chunjun-clients/target</directory>
  <outputDirectory>lib</outputDirectory>
  <includes>
   <include>chunjun-clients.jar</include>
  </includes>
</fileSet>
after run mvn clean  package -DskipTests
successfully got lib/chunjun-clients.jar
```
<br/>
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/20246692/222332898-5d284614-e6c6-4105-aef5-3b1959727d01.png">
<br/>

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

## Which issue you fix
Fixes # (issue).

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
