### PR TITLE
[hotfix-#1559][jdbc-connector] remove redundant comma of querySplitRangeSql

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/SqlUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/SqlUtil.java
@@ -41,7 +41,7 @@ public class SqlUtil {
         if (StringUtils.isNotEmpty(jdbcConfig.getCustomSql())) {
             querySplitRangeSql =
                     String.format(
-                            "SELECT min(%s.%s) as min_value,max(%s.%s) as max_value, FROM ( %s ) %s %s",
+                            "SELECT min(%s.%s) as min_value,max(%s.%s) as max_value FROM ( %s ) %s %s",
                             JdbcUtil.TEMPORARY_TABLE_NAME,
                             jdbcDialect.quoteIdentifier(jdbcConfig.getSplitPk()),
                             JdbcUtil.TEMPORARY_TABLE_NAME,


### PR DESCRIPTION
remove redundant comma of querySplitRangeSql, below sqls are the right  templates

```
"SELECT min(%s) as min_value ,max(%s) as max_value FROM (%s)tmp"

"SELECT min(%s) as min_value,max(%s) as max_value FROM %s %s"
```

## Which issue you fix
[Fixes # (issue).](https://github.com/DTStack/chunjun/issues/1559)

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
