### PR TITLE
[hotfix-#1577][sqlservercdc]Reacquire when connection is closed

### DIFF
--- a/chunjun-connectors/chunjun-connector-sqlservercdc/src/main/java/com/dtstack/chunjun/connector/sqlservercdc/listener/SqlServerCdcListener.java
+++ b/chunjun-connectors/chunjun-connector-sqlservercdc/src/main/java/com/dtstack/chunjun/connector/sqlservercdc/listener/SqlServerCdcListener.java
@@ -28,6 +28,7 @@ import com.dtstack.chunjun.connector.sqlservercdc.inputFormat.SqlServerCdcInputF
 import com.dtstack.chunjun.connector.sqlservercdc.util.SqlServerCdcUtil;
 import com.dtstack.chunjun.constants.ConstantValue;
 import com.dtstack.chunjun.converter.AbstractCDCRowConverter;
+import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
 import com.dtstack.chunjun.throwable.WriteRecordException;
 import com.dtstack.chunjun.util.Clock;
 import com.dtstack.chunjun.util.ExceptionUtil;
@@ -117,7 +118,21 @@ public class SqlServerCdcListener implements Runnable {
             } catch (Exception e) {
                 String errorMessage = ExceptionUtil.getErrorMessage(e);
                 log.error(errorMessage, e);
+                checkConnectionValid();
             }
+        }
+    }
+
+    private void checkConnectionValid() {
+        try {
+            // the sqlserver drivers is support isValid method
+            if (!conn.isValid(3)) {
+                log.warn("conn is invalid, try to reset connection.");
+                resetConnection();
+                log.warn("reset connection successfully.");
+            }
+        } catch (Throwable e) {
+            throw new ChunJunRuntimeException("check connection valid failed.", e);
         }
     }
 


### PR DESCRIPTION
…ilable

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->
Reacquire a connection when it is not available
## Which issue you fix
Fixes # (issue).
#1577 
## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
