### PR TITLE
[feat-#1586][hdfs]Fixed the problem of escaping the field delimiter

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/table/HdfsDynamicTableFactory.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/table/HdfsDynamicTableFactory.java
@@ -34,6 +34,8 @@ import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -136,7 +138,8 @@ public class HdfsDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         hdfsConfig.setDefaultFS(config.get(HdfsOptions.DEFAULT_FS));
         hdfsConfig.setFileType(config.get(HdfsOptions.FILE_TYPE));
         hdfsConfig.setFilterRegex(config.get(HdfsOptions.FILTER_REGEX));
-        hdfsConfig.setFieldDelimiter(config.get(HdfsOptions.FIELD_DELIMITER));
+        hdfsConfig.setFieldDelimiter(
+                StringEscapeUtils.unescapeJava(config.get(HdfsOptions.FIELD_DELIMITER)));
         hdfsConfig.setEnableDictionary(config.get(HdfsOptions.ENABLE_DICTIONARY));
 
         return hdfsConfig;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

解决字段分割符转义问题, 比如``` \t``` 会被转义成``` \\t```, 导致读取数据异常，误报成脏数据问题

## Which issue you fix
Fixes #1586 .

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
