### PR TITLE
[hotfix-#1596][core] Solve the problem that yarn-per-job sql mode does not exit when executing batch jobs

### DIFF
--- a/chunjun-core/src/main/java/com/dtstack/chunjun/util/PrintUtil.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/util/PrintUtil.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @Slf4j
 public class PrintUtil {
 
-    public static void printResult(Map<String, Object> result) {
+    public static String printResult(Map<String, Object> result) {
         List<String> names = Lists.newArrayList();
         List<String> values = Lists.newArrayList();
         result.forEach(
@@ -58,5 +58,6 @@ public class PrintUtil {
         }
         builder.append("\n*********************************************\n");
         log.info(builder.toString());
+        return builder.toString();
     }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

解决yarn-per-job sql 模式执行不退出问题 解决大并行度时获取统计指标报错问题.
只有在 confProp '{ "chunjun.cluster.execution-mode":"NORMAL"}' 增加此配置参数后才会触发。
由于在 log.info 无法将结果输出到终端上，因此使用 System.out.println()输出。
修复完执行效果如下，

![image](https://user-images.githubusercontent.com/3014381/229083256-6cb22392-8173-40b5-83f2-88187ddf734f.png)


## Which issue you fix
Fixes #1596 

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
