### PR TITLE
[hotfix-#1610][core]Fixed the sql parsing error of sink post-sql aining the set keyword

### DIFF
--- a/chunjun-core/src/main/java/com/dtstack/chunjun/sql/parser/SetStmtParser.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/sql/parser/SetStmtParser.java
@@ -22,6 +22,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.net.URL;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -39,7 +41,9 @@ public class SetStmtParser extends AbstractStmtParser {
 
     @Override
     public boolean canHandle(String stmt) {
-        return SET_PATTERN.matcher(stmt).find();
+        return StringUtils.isNotBlank(stmt)
+                && stmt.trim().toLowerCase().startsWith("set")
+                && SET_PATTERN.matcher(stmt).find();
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

解决sink.post-sql里的包含set 关键字导致sql解析错误

## Which issue you fix
Fixes #1610 

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
