### PR TITLE
[feat-#1647][hdfs] Support to generate an empty file with a specified file name in the target directory, and other optimization

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hdfs/pom.xml
@@ -113,6 +113,26 @@
 					<artifactId>commons-httpclient</artifactId>
 					<groupId>commons-httpclient</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-yarn-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<artifactId>hadoop-yarn-common</artifactId>
+					<groupId>org.apache.hadoop</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>hadoop-yarn-server-applicationhistoryservice</artifactId>
+					<groupId>org.apache.hadoop</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>hadoop-yarn-server-common</artifactId>
+					<groupId>org.apache.hadoop</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+					<groupId>org.apache.hadoop</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -212,6 +232,28 @@
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<filters>
+								<filter>
+									<artifact>org.apache.hive:hive-exec</artifact>
+									<excludes>
+										<exclude>parquet/**</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/config/HdfsConfig.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/config/HdfsConfig.java
@@ -44,4 +44,5 @@ public class HdfsConfig extends BaseFileConfig {
     private boolean enableDictionary = true;
     private List<String> fullColumnName;
     private List<String> fullColumnType;
+    private String finishedFileName;
 }

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/converter/HdfsTextColumnConverter.java
@@ -28,6 +28,7 @@ import com.dtstack.chunjun.element.ColumnRowData;
 import com.dtstack.chunjun.element.column.BigDecimalColumn;
 import com.dtstack.chunjun.element.column.BooleanColumn;
 import com.dtstack.chunjun.element.column.ByteColumn;
+import com.dtstack.chunjun.element.column.NullColumn;
 import com.dtstack.chunjun.element.column.SqlDateColumn;
 import com.dtstack.chunjun.element.column.StringColumn;
 import com.dtstack.chunjun.element.column.TimestampColumn;
@@ -76,13 +77,14 @@ public class HdfsTextColumnConverter
             GenericRowData genericRowData = (GenericRowData) input;
             List<FieldConfig> fieldConfigList = commonConfig.getColumn();
             for (int i = 0; i < input.getArity(); i++) {
-                row.addField(
-                        assembleFieldProps(
-                                fieldConfigList.get(i),
-                                (AbstractBaseColumn)
-                                        toInternalConverters
-                                                .get(i)
-                                                .deserialize(genericRowData.getField(i))));
+                AbstractBaseColumn baseColumn =
+                        (AbstractBaseColumn)
+                                toInternalConverters.get(i).deserialize(genericRowData.getField(i));
+                if (baseColumn != null) {
+                    row.addField(assembleFieldProps(fieldConfigList.get(i), baseColumn));
+                } else {
+                    row.addField(new NullColumn());
+                }
             }
         } else {
             throw new ChunJunRuntimeException(

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/options/HdfsOptions.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/options/HdfsOptions.java
@@ -76,4 +76,10 @@ public class HdfsOptions extends BaseFileOptions {
     private static boolean hasHadoopConfig(Map<String, String> tableOptions) {
         return tableOptions.keySet().stream().anyMatch((k) -> k.startsWith("properties."));
     }
+
+    public static final ConfigOption<String> SINK_COMMIT_FINISHED_FILE_NAME =
+            ConfigOptions.key("sink.commit.finished-file.name")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("The file name for finished-file partition commit policy");
 }

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.common.functions.RuntimeContext;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -229,6 +230,13 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
         }
         String currentFilePath = "";
         try {
+            // 在目标目录下生成一个指定文件名的空文件，例如：_SUCCESS 空文件
+            if (StringUtils.isNotBlank(hdfsConfig.getFinishedFileName())) {
+                String finishedFilePath =
+                        tmpPath + getHdfsPathChar() + hdfsConfig.getFinishedFileName();
+                fs.create(new Path(finishedFilePath), true);
+                log.info("Committed with finished file:{}", finishedFilePath);
+            }
             Path dir = new Path(outputFilePath);
             Path tmpDir = new Path(tmpPath);
 

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/table/HdfsDynamicTableFactory.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/table/HdfsDynamicTableFactory.java
@@ -74,6 +74,7 @@ public class HdfsDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         options.add(HdfsOptions.FILTER_REGEX);
         options.add(HdfsOptions.FIELD_DELIMITER);
         options.add(HdfsOptions.ENABLE_DICTIONARY);
+        options.add(HdfsOptions.SINK_COMMIT_FINISHED_FILE_NAME);
         return options;
     }
 
@@ -141,6 +142,7 @@ public class HdfsDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         hdfsConfig.setFieldDelimiter(
                 StringEscapeUtils.unescapeJava(config.get(HdfsOptions.FIELD_DELIMITER)));
         hdfsConfig.setEnableDictionary(config.get(HdfsOptions.ENABLE_DICTIONARY));
+        hdfsConfig.setFinishedFileName(config.get(HdfsOptions.SINK_COMMIT_FINISHED_FILE_NAME));
 
         return hdfsConfig;
     }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

解决以下问题：

优化点：
1、修复 java.io.EOFException: Unexpected end of input stream
2、排除 hadoop 相关依赖包
3、解决ClassCastException NULL空值问题
4、支持在目标目录下生成一个指定文件名的空文件，例如：_SUCCESS 空文件
5、读取时，当hdfs source中只定义一个字段时，该值是 一行nginx log的话（ 127.239.193.194 - - [14/Sep/2020:00:51:59 +0800] "GET /safe/tray.html? ），字段分割为空时，读取出来的数据缺失问题。


## Which issue you fix
Fixes #1647 

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
