### PR TITLE
Fix EmqxRowConverter.toExternal NullPointerException

### DIFF
--- a/chunjun-connectors/chunjun-connector-emqx/src/main/java/com/dtstack/chunjun/connector/emqx/converter/EmqxRowConverter.java
+++ b/chunjun-connectors/chunjun-connector-emqx/src/main/java/com/dtstack/chunjun/connector/emqx/converter/EmqxRowConverter.java
@@ -54,6 +54,11 @@ public class EmqxRowConverter
 
     @Override
     public MqttMessage toExternal(RowData rowData, MqttMessage output) {
+      try {
+            valueSerialization.open(null);
+           } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         final byte[] valueSerialized = valueSerialization.serialize(rowData);
         output.setPayload(valueSerialized);
         return output;


### PR DESCRIPTION

## Purpose of this pull request
  由于>=1.13版本flink对 JsonRowDataSerializationSchema 对象内部方法做了调整；mapper对象的创建需要调用open方法；以前低版本<=1.12 直接在成员属性中直接new的；因此不会出现空指针；
## Which issue you fix
   参考:https://github.com/DTStack/chunjun/issues/1673
## Checklist:
   测试了MyCDC写入到MQTT正常；测试环境为Flink1.16.1版本;Hadoop版本为3.2.2