### PR TITLE
针对时间精度，默认为毫秒

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/JdbcUtil.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/util/JdbcUtil.java
@@ -392,20 +392,7 @@ public class JdbcUtil {
      */
     public static int getNanos(long startLocation) {
         String timeStr = String.valueOf(startLocation);
-        int nanos;
-        if (timeStr.length() == SECOND_LENGTH) {
-            nanos = 0;
-        } else if (timeStr.length() == MILLIS_LENGTH) {
-            nanos = Integer.parseInt(timeStr.substring(SECOND_LENGTH, MILLIS_LENGTH)) * 1000000;
-        } else if (timeStr.length() == MICRO_LENGTH) {
-            nanos = Integer.parseInt(timeStr.substring(SECOND_LENGTH, MICRO_LENGTH)) * 1000;
-        } else if (timeStr.length() == NANOS_LENGTH) {
-            nanos = Integer.parseInt(timeStr.substring(SECOND_LENGTH, NANOS_LENGTH));
-        } else {
-            throw new IllegalArgumentException("Unknown time unit:startLocation=" + startLocation);
-        }
-
-        return nanos;
+        return Integer.parseInt(timeStr.substring(SECOND_LENGTH)) * 1000000;
     }
 
     /**
@@ -415,21 +402,7 @@ public class JdbcUtil {
      * @return
      */
     public static long getMillis(long startLocation) {
-        String timeStr = String.valueOf(startLocation);
-        long millisSecond;
-        if (timeStr.length() == SECOND_LENGTH) {
-            millisSecond = startLocation * 1000;
-        } else if (timeStr.length() == MILLIS_LENGTH) {
-            millisSecond = startLocation;
-        } else if (timeStr.length() == MICRO_LENGTH) {
-            millisSecond = startLocation / 1000;
-        } else if (timeStr.length() == NANOS_LENGTH) {
-            millisSecond = startLocation / 1000000;
-        } else {
-            throw new IllegalArgumentException("Unknown time unit:startLocation=" + startLocation);
-        }
-
-        return millisSecond;
+        return startLocation;
     }
 
     /**


### PR DESCRIPTION
## Purpose of this pull request
解决JdbcUtil格式化时间戳转换为毫秒和提取纳秒的精度问题，修改为默认单位为毫秒，不再进行多余的判断，因为无法判断传入的时间戳是什么类型的

## Which issue you fix
Fixes # (1699).

## Checklist:

- [ yes ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ yes ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ yes ] I have performed a self-review of my own code.
- [ yes ] I have commented my code, particularly in hard-to-understand areas.
- [yes  ] I have made corresponding changes to the documentation.
- [ yes ] I have added tests that prove my fix is effective or that my feature works.
- [ yes ] New and existing unit tests pass locally with my changes.
- [ yes ] I have checked my code and corrected any misspellings.
- [ yes ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
