### PR TITLE
[hotfix-#1701][connector][ftp] fixed Read timed out

### DIFF
--- a/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/converter/DummyInitializationContext.java
+++ b/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/converter/DummyInitializationContext.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dtstack.chunjun.connector.ftp.converter;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
+
+/** A dummy context for serialization schemas. */
+public class DummyInitializationContext
+        implements SerializationSchema.InitializationContext,
+                DeserializationSchema.InitializationContext {
+
+    @Override
+    public MetricGroup getMetricGroup() {
+        return new UnregisteredMetricsGroup();
+    }
+
+    @Override
+    public UserCodeClassLoader getUserCodeClassLoader() {
+        return SimpleUserCodeClassLoader.create(DummyInitializationContext.class.getClassLoader());
+    }
+}

--- a/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/converter/FtpSqlConverter.java
+++ b/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/converter/FtpSqlConverter.java
@@ -43,11 +43,13 @@ public class FtpSqlConverter extends AbstractRowConverter<String, String, String
 
     @Override
     public RowData toInternal(String input) throws Exception {
+        valueDeserialization.open(new DummyInitializationContext());
         return valueDeserialization.deserialize(input.getBytes());
     }
 
     @Override
     public String toExternal(RowData rowData, String output) throws Exception {
+        valueSerialization.open(new DummyInitializationContext());
         byte[] serialize = valueSerialization.serialize(rowData);
         return new String(serialize);
     }

--- a/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/handler/FtpHandler.java
+++ b/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/handler/FtpHandler.java
@@ -149,14 +149,19 @@ public class FtpHandler implements DTFtpHandler {
     @Override
     public boolean isFileExist(String filePath) throws IOException {
         ftpClient.enterLocalPassiveMode();
-        try (InputStream inputStream = ftpClient.retrieveFileStream(encodePath(filePath))) {
-            return inputStream != null && ftpClient.getReplyCode() != 550;
+        InputStream inputStream = null;
+        try {
+            inputStream = ftpClient.retrieveFileStream(encodePath(filePath));
+            return inputStream != null && ftpClient.getReplyCode() != FTPReply.FILE_UNAVAILABLE;
         } catch (IOException e) {
             throw new ChunJunRuntimeException(
                     "An exception occurred when judging whether the file exists. filepath: "
                             + filePath);
         } finally {
-            ftpClient.completePendingCommand();
+            if (inputStream != null) {
+                inputStream.close();
+                ftpClient.completePendingCommand();
+            }
         }
     }
 

--- a/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/sink/FtpOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/sink/FtpOutputFormat.java
@@ -49,6 +49,8 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
     /** 换行符 */
     private static final int NEWLINE = 10;
 
+    private static final String SP = "/";
+
     private static final long serialVersionUID = -3331910729974811530L;
 
     protected FtpConfig ftpConfig;
@@ -101,7 +103,7 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
         if (writer != null) {
             return;
         }
-        String currentBlockTmpPath = tmpPath + File.separatorChar + currentFileName;
+        String currentBlockTmpPath = tmpPath + SP + currentFileName;
         try {
             os = ftpHandler.getOutputStream(currentBlockTmpPath);
             writer =
@@ -212,7 +214,7 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
                 String fileName =
                         handleUserSpecificFileName(
                                 tmpDataFile.getName(), dataFiles.size(), copyList, ftpHandler);
-                String newFilePath = outputFilePath + File.separatorChar + fileName;
+                String newFilePath = outputFilePath + SP + fileName;
                 ftpHandler.rename(currentFilePath, newFilePath);
                 copyList.add(newFilePath);
                 log.info("copy temp file:{} to dir:{}", currentFilePath, outputFilePath);
@@ -253,7 +255,7 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
                         List<String> copyList = new ArrayList<>();
                         for (String dataFile : dataFiles) {
                             File tmpDataFile = new File(dataFile);
-                            dataFilePath = tmpDataFile.getAbsolutePath();
+                            dataFilePath = dataFile;
 
                             String fileName =
                                     handleUserSpecificFileName(
@@ -261,8 +263,7 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
                                             dataFiles.size(),
                                             copyList,
                                             handler);
-                            String newDataFilePath =
-                                    ftpConfig.getPath() + File.separatorChar + fileName;
+                            String newDataFilePath = ftpConfig.getPath() + SP + fileName;
                             handler.rename(dataFilePath, newDataFilePath);
                             copyList.add(newDataFilePath);
                             log.info("move temp file:{} to dir:{}", dataFilePath, outputFilePath);
@@ -285,12 +286,15 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
 
     @Override
     protected String getExtension() {
+        if (StringUtils.isNotBlank(ftpConfig.getFileType())) {
+            return ftpConfig.getFileType();
+        }
         return "";
     }
 
     @Override
     protected long getCurrentFileSize() {
-        String path = tmpPath + File.separatorChar + currentFileName;
+        String path = tmpPath + SP + currentFileName;
         try {
             return ftpHandler.getFileSize(path);
         } catch (IOException e) {
@@ -351,7 +355,7 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
     private String filepathCheck(String filename, List<String> copyList, DTFtpHandler handler)
             throws IOException {
         if (WriteMode.NONCONFLICT.name().equalsIgnoreCase(ftpConfig.getWriteMode())) {
-            if (handler.isFileExist(ftpConfig.getPath() + File.separatorChar + filename)) {
+            if (handler.isFileExist(ftpConfig.getPath() + SP + filename)) {
                 handler.deleteAllFilesInDir(tmpPath, null);
                 if (!copyList.isEmpty()) {
                     for (String filePath : copyList) {
@@ -367,7 +371,7 @@ public class FtpOutputFormat extends BaseFileOutputFormat {
                         String.format("the file: %s already exists", filename));
             }
         } else if (WriteMode.INSERT.name().equalsIgnoreCase(ftpConfig.getWriteMode())) {
-            if (handler.isFileExist(ftpConfig.getPath() + File.separatorChar + filename)) {
+            if (handler.isFileExist(ftpConfig.getPath() + SP + filename)) {
                 String suffix =
                         StringUtils.isNotBlank(ftpConfig.getSuffix())
                                 ? "_" + ftpConfig.getSuffix()

--- a/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/spliter/ConcurrentZipCompressSplit.java
+++ b/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/spliter/ConcurrentZipCompressSplit.java
@@ -54,7 +54,7 @@ public class ConcurrentZipCompressSplit extends DefaultFileSplit {
             while ((zipEntry = zipInputStream.getNextEntry()) != null) {
                 fileSplits.add(
                         new FtpFileSplit(
-                                0, zipEntry.getSize(), filePath, zipEntry.getName(), compressType));
+                                0, zipEntry.getSize(), zipEntry.getName(), filePath, compressType));
             }
             return fileSplits;
         } catch (Exception e) {

--- a/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/table/FtpDynamicTableFactory.java
+++ b/chunjun-connectors/chunjun-connector-ftp/src/main/java/com/dtstack/chunjun/connector/ftp/table/FtpDynamicTableFactory.java
@@ -68,6 +68,7 @@ public class FtpDynamicTableFactory implements DynamicTableSourceFactory, Dynami
         ftpConfig.setMaxFileSize(config.get(BaseFileOptions.MAX_FILE_SIZE));
         ftpConfig.setCompressType(config.get(FtpOptions.COMPRESS_TYPE));
         ftpConfig.setFileType(config.get(FtpOptions.FILE_TYPE));
+        ftpConfig.setNextCheckRows(config.get(BaseFileOptions.NEXT_CHECK_ROWS));
 
         if (!ConfigConstants.DEFAULT_FIELD_DELIMITER.equals(
                 config.get(FtpOptions.FIELD_DELIMITER))) {
@@ -179,6 +180,7 @@ public class FtpDynamicTableFactory implements DynamicTableSourceFactory, Dynami
         options.add(FtpOptions.FIRST_LINE_HEADER);
         options.add(FtpOptions.FIELD_DELIMITER);
         options.add(FtpOptions.COMPRESS_TYPE);
+        options.add(BaseFileOptions.NEXT_CHECK_ROWS);
         return options;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

1、解决 CsvRowDataDeserializationSchema objectReader 空指针问题
2、解决 ftpClient.completePendingCommand 当 inputStream 为null 读取超时问题，
3、统一 FtpOutputFormat 拼接路径使用的分割符
4、解决 ConcurrentZipCompressSplit 里初始化 FtpFileSplit 构造参数顺序问题，原因：读取的压缩包里路径不对 

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

## Which issue you fix
Fixes #1701

## Checklist:

- [x] I have executed the **'mvn spotless:apply'** command to format my code.
- [x] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have checked my code and corrected any misspellings.
- [x] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
