### PR TITLE
[hotfix-#1718] Dirty data is collected for all slots, not for a single slot

### DIFF
--- a/chunjun-connectors/chunjun-connector-elasticsearch6/src/main/java/com/dtstack/chunjun/connector/elasticsearch6/sink/Elasticsearch6OutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-elasticsearch6/src/main/java/com/dtstack/chunjun/connector/elasticsearch6/sink/Elasticsearch6OutputFormat.java
@@ -22,6 +22,7 @@ import com.dtstack.chunjun.connector.elasticsearch.KeyExtractor;
 import com.dtstack.chunjun.connector.elasticsearch6.Elasticsearch6ClientFactory;
 import com.dtstack.chunjun.connector.elasticsearch6.Elasticsearch6Config;
 import com.dtstack.chunjun.connector.elasticsearch6.Elasticsearch6RequestFactory;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.sink.format.BaseRichOutputFormat;
 import com.dtstack.chunjun.throwable.WriteRecordException;
 
@@ -112,7 +113,9 @@ public class Elasticsearch6OutputFormat extends BaseRichOutputFormat {
                             new WriteRecordException(
                                     itemResponds.getFailureMessage(),
                                     itemResponds.getFailure().getCause());
-                    dirtyManager.collect(response, exception, null);
+                    long globalErrors =
+                            accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+                    dirtyManager.collect(response, exception, null, globalErrors);
                 }
 
                 if (errCounter != null) {

--- a/chunjun-connectors/chunjun-connector-elasticsearch7/src/main/java/com/dtstack/chunjun/connector/elasticsearch7/sink/ElasticsearchOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-elasticsearch7/src/main/java/com/dtstack/chunjun/connector/elasticsearch7/sink/ElasticsearchOutputFormat.java
@@ -23,6 +23,7 @@ import com.dtstack.chunjun.connector.elasticsearch.table.IndexGenerator;
 import com.dtstack.chunjun.connector.elasticsearch7.Elasticsearch7ClientFactory;
 import com.dtstack.chunjun.connector.elasticsearch7.Elasticsearch7RequestFactory;
 import com.dtstack.chunjun.connector.elasticsearch7.ElasticsearchConfig;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.sink.WriteMode;
 import com.dtstack.chunjun.sink.format.BaseRichOutputFormat;
 import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
@@ -164,7 +165,9 @@ public class ElasticsearchOutputFormat extends BaseRichOutputFormat {
                             new WriteRecordException(
                                     itemResponds.getFailureMessage(),
                                     itemResponds.getFailure().getCause());
-                    dirtyManager.collect(response, exception, null);
+                    long globalErrors =
+                            accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+                    dirtyManager.collect(response, exception, null, globalErrors);
                 }
 
                 if (errCounter != null) {

--- a/chunjun-connectors/chunjun-connector-influxdb/src/main/java/com/dtstack/chunjun/connector/influxdb/sink/InfluxdbOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-influxdb/src/main/java/com/dtstack/chunjun/connector/influxdb/sink/InfluxdbOutputFormat.java
@@ -23,6 +23,7 @@ import com.dtstack.chunjun.connector.influxdb.config.InfluxdbSinkConfig;
 import com.dtstack.chunjun.connector.influxdb.converter.InfluxdbRawTypeMapper;
 import com.dtstack.chunjun.connector.influxdb.converter.InfluxdbSyncConverter;
 import com.dtstack.chunjun.connector.influxdb.enums.TimePrecisionEnums;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.sink.format.BaseRichOutputFormat;
 import com.dtstack.chunjun.throwable.WriteRecordException;
 import com.dtstack.chunjun.util.ExceptionUtil;
@@ -135,7 +136,10 @@ public class InfluxdbOutputFormat extends BaseRichOutputFormat {
                     options.exceptionHandler(
                                     (iterable, e) -> {
                                         for (Point point : iterable) {
-                                            dirtyManager.collect(point, e, null);
+                                            long globalErrors =
+                                                    accumulatorCollector.getAccumulatorValue(
+                                                            Metrics.NUM_ERRORS, false);
+                                            dirtyManager.collect(point, e, null, globalErrors);
                                         }
                                         if (log.isTraceEnabled()) {
                                             log.trace(

--- a/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/serialization/RowDeserializationSchema.java
+++ b/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/serialization/RowDeserializationSchema.java
@@ -19,6 +19,7 @@ package com.dtstack.chunjun.connector.kafka.serialization;
 
 import com.dtstack.chunjun.connector.kafka.conf.KafkaConfig;
 import com.dtstack.chunjun.connector.kafka.source.DynamicKafkaDeserializationSchema;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.converter.AbstractRowConverter;
 import com.dtstack.chunjun.util.JsonUtil;
 
@@ -74,7 +75,9 @@ public class RowDeserializationSchema extends DynamicKafkaDeserializationSchema 
             if (record.value() != null) {
                 data = new String(record.value(), StandardCharsets.UTF_8);
             }
-            dirtyManager.collect(data, e, null);
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+            dirtyManager.collect(
+                    new String(record.value(), StandardCharsets.UTF_8), e, null, globalErrors);
         }
     }
 }

--- a/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/serialization/RowSerializationSchema.java
+++ b/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/serialization/RowSerializationSchema.java
@@ -21,6 +21,7 @@ import com.dtstack.chunjun.cdc.DdlRowData;
 import com.dtstack.chunjun.connector.kafka.conf.KafkaConfig;
 import com.dtstack.chunjun.connector.kafka.sink.DynamicKafkaSerializationSchema;
 import com.dtstack.chunjun.constants.CDCConstantValue;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.converter.AbstractRowConverter;
 import com.dtstack.chunjun.element.AbstractBaseColumn;
 import com.dtstack.chunjun.element.ColumnRowData;
@@ -99,7 +100,8 @@ public class RowSerializationSchema extends DynamicKafkaSerializationSchema {
                     null,
                     valueSerialized);
         } catch (Exception e) {
-            dirtyManager.collect(element, e, null);
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+            dirtyManager.collect(element, e, null, globalErrors);
         }
         return null;
     }

--- a/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/sink/DynamicKafkaSerializationSchema.java
+++ b/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/sink/DynamicKafkaSerializationSchema.java
@@ -265,7 +265,8 @@ public class DynamicKafkaSerializationSchema
                     valueSerialized,
                     readMetadata(consumedRow, KafkaDynamicSink.WritableMetadata.HEADERS));
         } catch (Exception e) {
-            dirtyManager.collect(consumedRow, e, null);
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+            dirtyManager.collect(consumedRow, e, null, globalErrors);
         }
         return null;
     }

--- a/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/source/DynamicKafkaDeserializationSchema.java
+++ b/chunjun-connectors/chunjun-connector-kafka/src/main/java/com/dtstack/chunjun/connector/kafka/source/DynamicKafkaDeserializationSchema.java
@@ -231,7 +231,9 @@ public class DynamicKafkaDeserializationSchema implements KafkaDeserializationSc
             if (record.value() != null) {
                 data = new String(record.value(), StandardCharsets.UTF_8);
             }
-            dirtyManager.collect(data, e, null);
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+
+            dirtyManager.collect(data, e, null, globalErrors);
         }
     }
 

--- a/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/sink/MongodbOutputFormatBuilder.java
+++ b/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/sink/MongodbOutputFormatBuilder.java
@@ -56,6 +56,11 @@ public class MongodbOutputFormatBuilder extends BaseRichOutputFormatBuilder<Mong
 
     @Override
     protected void checkFormat() {
+        // mongodbDataSyncConf 是json模式下的实体类
+        // sql 模式这里跳过检查
+        if (mongodbDataSyncConfig == null) {
+            return;
+        }
         if (!StringUtils.isBlank(upsertKey)) {
             List<FieldConfig> fields = mongodbDataSyncConfig.getColumn();
             boolean flag = false;

--- a/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/source/MongodbInputFormatBuilder.java
+++ b/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/source/MongodbInputFormatBuilder.java
@@ -42,6 +42,13 @@ public class MongodbInputFormatBuilder extends BaseRichInputFormatBuilder<Mongod
         return new MongodbInputFormatBuilder(format);
     }
 
+    public static MongodbInputFormatBuilder newBuild(
+            MongoClientConfig mongoClientConf, String filter, int fetchSize) {
+        MongodbInputFormat format =
+                new MongodbInputFormat(mongoClientConf, parseFilter(filter), fetchSize);
+        return new MongodbInputFormatBuilder(format);
+    }
+
     private MongodbInputFormatBuilder(MongodbInputFormat format) {
         super(format);
     }

--- a/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/table/MongodbDynamicTableFactory.java
+++ b/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/table/MongodbDynamicTableFactory.java
@@ -74,7 +74,10 @@ public class MongodbDynamicTableFactory
 
         LookupConfig lookupConfig = LookupConfigFactory.createLookupConfig(config);
         return new MongodbDynamicTableSource(
-                mongoClientConfig, lookupConfig, context.getCatalogTable().getResolvedSchema());
+                mongoClientConfig,
+                lookupConfig,
+                context.getCatalogTable().getResolvedSchema(),
+                config);
     }
 
     /**
@@ -103,6 +106,8 @@ public class MongodbDynamicTableFactory
         optionalOptions.add(MongoClientOptions.PASSWORD);
 
         optionalOptions.add(SCAN_PARALLELISM);
+        optionalOptions.add(MongoClientOptions.FILTER);
+        optionalOptions.add(MongoClientOptions.FETCH_SIZE);
 
         optionalOptions.add(LOOKUP_CACHE_PERIOD);
         optionalOptions.add(LOOKUP_CACHE_MAX_ROWS);

--- a/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/table/MongodbDynamicTableSource.java
+++ b/chunjun-connectors/chunjun-connector-mongodb/src/main/java/com/dtstack/chunjun/connector/mongodb/table/MongodbDynamicTableSource.java
@@ -19,18 +19,29 @@
 package com.dtstack.chunjun.connector.mongodb.table;
 
 import com.dtstack.chunjun.connector.mongodb.config.MongoClientConfig;
+import com.dtstack.chunjun.connector.mongodb.converter.MongodbSqlConverter;
+import com.dtstack.chunjun.connector.mongodb.datasync.MongodbDataSyncConfig;
+import com.dtstack.chunjun.connector.mongodb.source.MongodbInputFormatBuilder;
 import com.dtstack.chunjun.connector.mongodb.table.lookup.MongoAllTableFunction;
 import com.dtstack.chunjun.connector.mongodb.table.lookup.MongoLruTableFunction;
+import com.dtstack.chunjun.connector.mongodb.table.options.MongoClientOptions;
 import com.dtstack.chunjun.enums.CacheType;
 import com.dtstack.chunjun.lookup.config.LookupConfig;
+import com.dtstack.chunjun.source.DtInputFormatSourceFunction;
+import com.dtstack.chunjun.source.options.SourceOptions;
 import com.dtstack.chunjun.table.connector.source.ParallelAsyncLookupFunctionProvider;
 import com.dtstack.chunjun.table.connector.source.ParallelLookupFunctionProvider;
+import com.dtstack.chunjun.table.connector.source.ParallelSourceFunctionProvider;
 
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
@@ -41,14 +52,17 @@ public class MongodbDynamicTableSource implements ScanTableSource, LookupTableSo
     private final MongoClientConfig mongoClientConfig;
     private final ResolvedSchema resolvedSchema;
     private final LookupConfig lookupConfig;
+    private final ReadableConfig config;
 
     public MongodbDynamicTableSource(
             MongoClientConfig mongoClientConfig,
             LookupConfig lookupConfig,
-            ResolvedSchema resolvedSchema) {
+            ResolvedSchema resolvedSchema,
+            ReadableConfig config) {
         this.mongoClientConfig = mongoClientConfig;
         this.lookupConfig = lookupConfig;
         this.resolvedSchema = resolvedSchema;
+        this.config = config;
     }
 
     @Override
@@ -86,10 +100,48 @@ public class MongodbDynamicTableSource implements ScanTableSource, LookupTableSo
         }
     }
 
+    /**
+     * ScanTableSource独有
+     *
+     * @param runtimeProviderContext
+     * @return
+     */
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        final RowType rowType = (RowType) resolvedSchema.toPhysicalRowDataType().getLogicalType();
+        TypeInformation<RowData> typeInformation = InternalTypeInfo.of(rowType);
+
+        MongodbDataSyncConfig mongodbDataSyncConf = new MongodbDataSyncConfig();
+        config.getOptional(MongoClientOptions.URI).ifPresent(mongodbDataSyncConf::setUrl);
+        config.getOptional(MongoClientOptions.DATABASE).ifPresent(mongodbDataSyncConf::setDatabase);
+        config.getOptional(MongoClientOptions.COLLECTION)
+                .ifPresent(mongodbDataSyncConf::setCollectionName);
+        config.getOptional(MongoClientOptions.USERNAME).ifPresent(mongodbDataSyncConf::setUsername);
+        config.getOptional(MongoClientOptions.PASSWORD).ifPresent(mongodbDataSyncConf::setPassword);
+        String filter = config.getOptional(MongoClientOptions.FILTER).orElse(null);
+        String fetchsize = config.getOptional(MongoClientOptions.FETCH_SIZE).orElse("0");
+        Integer parallelism = config.getOptional(SourceOptions.SCAN_PARALLELISM).orElse(1);
+
+        MongodbInputFormatBuilder builder =
+                MongodbInputFormatBuilder.newBuild(
+                        mongoClientConfig, filter, Integer.parseInt(fetchsize));
+        MongodbSqlConverter mongodbSqlConverter =
+                new MongodbSqlConverter(
+                        rowType, resolvedSchema.getColumnNames().toArray(new String[0]));
+
+        builder.setRowConverter(mongodbSqlConverter);
+        builder.setConfig(mongodbDataSyncConf);
+
+        return ParallelSourceFunctionProvider.of(
+                new DtInputFormatSourceFunction<>(builder.finish(), typeInformation),
+                false,
+                parallelism);
+    }
+
     @Override
     public DynamicTableSource copy() {
         return new MongodbDynamicTableSource(
-                this.mongoClientConfig, this.lookupConfig, this.resolvedSchema);
+                this.mongoClientConfig, this.lookupConfig, this.resolvedSchema, this.config);
     }
 
     @Override
@@ -100,10 +152,5 @@ public class MongodbDynamicTableSource implements ScanTableSource, LookupTableSo
     @Override
     public ChangelogMode getChangelogMode() {
         return ChangelogMode.insertOnly();
-    }
-
-    @Override
-    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
-        return null;
     }
 }

--- a/chunjun-connectors/chunjun-connector-nebula/src/main/java/com/dtstack/chunjun/connector/nebula/sink/NebulaOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-nebula/src/main/java/com/dtstack/chunjun/connector/nebula/sink/NebulaOutputFormat.java
@@ -23,6 +23,7 @@ import com.dtstack.chunjun.connector.nebula.client.NebulaSession;
 import com.dtstack.chunjun.connector.nebula.client.NebulaStorageClient;
 import com.dtstack.chunjun.connector.nebula.config.NebulaConfig;
 import com.dtstack.chunjun.connector.nebula.row.NebulaRows;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.sink.format.BaseRichOutputFormat;
 import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
 import com.dtstack.chunjun.throwable.WriteRecordException;
@@ -134,7 +135,9 @@ public class NebulaOutputFormat extends BaseRichOutputFormat {
                             new WriteRecordException(
                                     res.getErrorMessage(),
                                     new ChunJunRuntimeException(res.getErrorMessage()));
-                    dirtyManager.collect(row, exception, null);
+                    long globalErrors =
+                            accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+                    dirtyManager.collect(row, exception, null, globalErrors);
                 }
                 if (errCounter != null) {
                     errCounter.add(rows.size());
@@ -145,7 +148,9 @@ public class NebulaOutputFormat extends BaseRichOutputFormat {
             WriteRecordException exception;
             for (RowData row : rows) {
                 exception = new WriteRecordException(e.getMessage(), e);
-                dirtyManager.collect(row, exception, null);
+                long globalErrors =
+                        accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+                dirtyManager.collect(row, exception, null, globalErrors);
             }
 
             if (errCounter != null) {

--- a/chunjun-connectors/chunjun-connector-rocketmq/src/main/java/com/dtstack/chunjun/connector/rocketmq/source/deserialization/RowKeyValueDeserializationSchema.java
+++ b/chunjun-connectors/chunjun-connector-rocketmq/src/main/java/com/dtstack/chunjun/connector/rocketmq/source/deserialization/RowKeyValueDeserializationSchema.java
@@ -212,7 +212,8 @@ public class RowKeyValueDeserializationSchema implements KeyValueDeserialization
         try {
             return converter.toInternal(value);
         } catch (Exception e) {
-            dirtyManager.collect(value, e, null);
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+            dirtyManager.collect(value, e, null, globalErrors);
         }
         return null;
     }

--- a/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/sink/StarRocksOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/sink/StarRocksOutputFormat.java
@@ -23,6 +23,7 @@ import com.dtstack.chunjun.connector.starrocks.config.StarRocksConfig;
 import com.dtstack.chunjun.connector.starrocks.streamload.StarRocksSinkBufferEntity;
 import com.dtstack.chunjun.connector.starrocks.streamload.StarRocksStreamLoadFailedException;
 import com.dtstack.chunjun.connector.starrocks.streamload.StreamLoadManager;
+import com.dtstack.chunjun.constants.Metrics;
 import com.dtstack.chunjun.sink.format.BaseRichOutputFormat;
 import com.dtstack.chunjun.throwable.ChunJunRuntimeException;
 
@@ -103,7 +104,10 @@ public class StarRocksOutputFormat extends BaseRichOutputFormat {
                     String errMessage = handleErrMessage(exception);
                     StarRocksSinkBufferEntity entity = exception.getEntity();
                     for (byte[] data : entity.getBuffer()) {
-                        dirtyManager.collect(new String(data), new Throwable(errMessage), null);
+                        long globalErrors =
+                                accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+                        dirtyManager.collect(
+                                new String(data), new Throwable(errMessage), null, globalErrors);
                     }
                 } else {
                     throw new ChunJunRuntimeException("write starRocks failed.", e);

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/dirty/manager/DirtyManager.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/dirty/manager/DirtyManager.java
@@ -116,7 +116,7 @@ public class DirtyManager implements Serializable {
         return consumer.getFailedConsumed();
     }
 
-    public void collect(Object data, Throwable cause, String field) {
+    public void collect(Object data, Throwable cause, String field, long globalErrors) {
         if (executor == null) {
             execute();
         }
@@ -131,7 +131,7 @@ public class DirtyManager implements Serializable {
         entity.setFieldName(field);
         entity.setErrorMessage(ExceptionUtil.getErrorMessage(cause));
 
-        consumer.offer(entity);
+        consumer.offer(entity, globalErrors);
         errorCounter.add(1L);
     }
 

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/sink/format/BaseRichOutputFormat.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/sink/format/BaseRichOutputFormat.java
@@ -488,7 +488,9 @@ public abstract class BaseRichOutputFormat extends RichOutputFormat<RowData>
             writeSingleRecordInternal(rowData);
             numWriteCounter.add(1L);
         } catch (WriteRecordException e) {
-            dirtyManager.collect(e.getRowData(), e, null);
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+
+            dirtyManager.collect(e.getRowData(), e, null, globalErrors);
             if (log.isTraceEnabled()) {
                 log.trace(
                         "write error rowData, rowData = {}, e = {}",

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/source/format/BaseRichInputFormat.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/source/format/BaseRichInputFormat.java
@@ -198,7 +198,9 @@ public abstract class BaseRichInputFormat extends RichInputFormat<RowData, Input
         try {
             internalRow = nextRecordInternal(rowData);
         } catch (ReadRecordException e) {
-            dirtyManager.collect(e.getRowData(), e, null);
+            // 脏数据总数应是所有slot的脏数据总数，而不是单个的
+            long globalErrors = accumulatorCollector.getAccumulatorValue(Metrics.NUM_ERRORS, false);
+            dirtyManager.collect(e.getRowData(), e, null, globalErrors);
         }
         if (internalRow != null) {
             updateDuration();

--- a/chunjun-core/src/test/java/com/dtstack/chunjun/dirty/consumer/DirtyDataCollectorTest.java
+++ b/chunjun-core/src/test/java/com/dtstack/chunjun/dirty/consumer/DirtyDataCollectorTest.java
@@ -69,8 +69,8 @@ class DirtyDataCollectorTest {
         dirtyDataCollector.maxConsumed = 2L;
         DirtyDataEntry dirty = new DirtyDataEntry();
         dirty.setDirtyContent("{}");
-        dirtyDataCollector.addConsumed(1L, dirty);
-        assertThrows(NoRestartException.class, () -> dirtyDataCollector.addConsumed(1L, dirty));
+        dirtyDataCollector.addConsumed(1L, dirty, 0L);
+        assertThrows(NoRestartException.class, () -> dirtyDataCollector.addConsumed(1L, dirty, 0));
     }
 
     @Test
@@ -89,7 +89,7 @@ class DirtyDataCollectorTest {
     void offerShouldAddDirtyDataToQueue() {
         dirtyDataCollector.maxConsumed = 2L;
         DirtyDataEntry dirtyDataEntry = new DirtyDataEntry();
-        dirtyDataCollector.offer(dirtyDataEntry);
+        dirtyDataCollector.offer(dirtyDataEntry, 0);
         assertEquals(1, dirtyDataCollector.consumeQueue.size());
     }
 
@@ -97,7 +97,7 @@ class DirtyDataCollectorTest {
     @DisplayName("Should increase the consumed counter by 1")
     void offerShouldIncreaseConsumedCounterBy1() {
         dirtyDataCollector.maxConsumed = 2L;
-        dirtyDataCollector.offer(new DirtyDataEntry());
+        dirtyDataCollector.offer(new DirtyDataEntry(), 0);
         assertEquals(1L, dirtyDataCollector.getConsumed().getLocalValue());
     }
 


### PR DESCRIPTION
  
通过定时请求（每tm心跳+1s）注册在jobmanager  的累加器，当请求时jobmanager会聚合所有的slot的累加器指标，此时我们关注脏数据总数：这里记为globalErrors。

通过这样获取的脏数据条数就是所有slot脏数据的总和，而不是单个slot的。

但因为总体的脏数据需要tm和jm进行通讯，会有延迟效应，所以统计的脏数据还没有100%准确，总会向上浮动

