### PR TITLE
[hotfix-1756][mysql]Fixed a decimal type precision calculation issue in MySQL

### DIFF
--- a/chunjun-connectors/chunjun-connector-mysql/src/main/java/com/dtstack/chunjun/connector/mysql/dialect/MysqlDialect.java
+++ b/chunjun-connectors/chunjun-connector-mysql/src/main/java/com/dtstack/chunjun/connector/mysql/dialect/MysqlDialect.java
@@ -145,8 +145,6 @@ public class MysqlDialect implements JdbcDialect {
                     && precision > 10) {
                 // "." 还占一个字符长度，需要去掉.
                 scale = precision - 10 - 1;
-            } else if (columnTypeName.toUpperCase(Locale.ENGLISH).contains("DECIMAL")) {
-                precision = precision - scale;
             }
             TypeConfig typeConfig = TypeConfig.fromString(columnTypeName);
             typeConfig.setPrecision(precision);


### PR DESCRIPTION
Fixed a decimal type precision calculation issue in MySQL

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
Fixed a decimal type precision calculation issue in MySQL

## Which issue you fix
https://github.com/DTStack/chunjun/issues/1756

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
