### PR TITLE
[hotfix-#1771] [connector][starrocks] The sr table was not partitioned, causing data consumption to fail but the flink task presentation to succeed

### DIFF
--- a/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/sink/StarRocksOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/sink/StarRocksOutputFormat.java
@@ -51,6 +51,11 @@ public class StarRocksOutputFormat extends BaseRichOutputFormat {
                         .collect(Collectors.toList());
 
         streamLoadManager = new StreamLoadManager(starRocksConfig);
+        if (!streamLoadManager.tableHasPartition()) {
+            throw new RuntimeException(
+                    "data cannot be inserted into table with empty partition. "
+                            + "Use `SHOW PARTITIONS FROM star_test` to see the currently partitions of this table");
+        }
         streamLoadManager.startAsyncFlushing();
         if (starRocksConfig.isNameMapped()) {
             writeProcessor = new MappedWriteProcessor(streamLoadManager, starRocksConfig);

--- a/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/streamload/StarRocksQueryVisitor.java
+++ b/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/streamload/StarRocksQueryVisitor.java
@@ -134,4 +134,20 @@ public class StarRocksQueryVisitor implements Serializable {
     public void close() {
         jdbcConnProvider.close();
     }
+
+    public boolean hasPartitions(String database, String table) {
+        ResultSet rs;
+        try {
+            jdbcConnProvider.checkValid();
+            final String query = "SHOW PARTITIONS FROM " + database + "." + table + ";";
+            PreparedStatement stmt = jdbcConnProvider.getConnection().prepareStatement(query);
+            rs = stmt.executeQuery();
+            return rs.next();
+        } catch (ClassNotFoundException se) {
+            throw new IllegalArgumentException("Failed to find jdbc driver." + se.getMessage(), se);
+        } catch (SQLException se) {
+            throw new IllegalArgumentException(
+                    "Failed to get table partition info from StarRocks. " + se.getMessage(), se);
+        }
+    }
 }

--- a/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/streamload/StreamLoadManager.java
+++ b/chunjun-connectors/chunjun-connector-starrocks/src/main/java/com/dtstack/chunjun/connector/starrocks/streamload/StreamLoadManager.java
@@ -327,4 +327,9 @@ public class StreamLoadManager {
         }
         checkFlushException();
     }
+
+    public boolean tableHasPartition() {
+        return starrocksQueryVisitor.hasPartitions(
+                starRocksConfig.getDatabase(), starRocksConfig.getTable());
+    }
 }


### PR DESCRIPTION


## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

修复因为starrocks没有创建分区，导致任务失败但flink任务实际展示为成功，且有写成功条数等信息

## Which issue you fix
Fixes #1771  (issue).

