### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.21.7

### DIFF
--- a/chunjun-connectors/chunjun-connector-oceanbasecdc/pom.xml
+++ b/chunjun-connectors/chunjun-connector-oceanbasecdc/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.18.2</version>
+			<version>3.21.7</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.protobuf:protobuf-java 3.18.2
- [CVE-2022-3509](https://www.oscs1024.com/hd/CVE-2022-3509)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.18.2 to 3.21.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS