### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<chunjun.guava.version>27.0-jre</chunjun.guava.version>
 		<guava.version>19.0</guava.version>
 		<auto-service.version>1.0.1</auto-service.version>
-		<hadoop2.version>2.8.5</hadoop2.version>
+		<hadoop2.version>3.3.3</hadoop2.version>
 		<hadoop3.version>3.2.4</hadoop3.version>
 		<snappy-java.version>1.1.8.3</snappy-java.version>
 		<checker.qual.version>3.10.0</checker.qual.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-common 2.8.5
- [CVE-2022-25168](https://www.oscs1024.com/hd/CVE-2022-25168)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 2.8.5 to 3.3.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS