### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-http to 12.0.0.beta0

### DIFF
--- a/chunjun-connectors/chunjun-connector-hudi/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hudi/pom.xml
@@ -36,7 +36,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jetty.version>9.4.48.v20220622</jetty.version>
+		<jetty.version>11.0.10</jetty.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-http 9.4.48.v20220622
- [CVE-2022-2047](https://www.oscs1024.com/hd/CVE-2022-2047)


### What did I do？
Upgrade org.eclipse.jetty:jetty-http from 9.4.48.v20220622 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS