### PR TITLE
fix(sec): upgrade org.xerial.snappy:snappy-java to 1.1.10.1

### DIFF
--- a/chunjun-connectors/chunjun-connector-hive3/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive3/pom.xml
@@ -362,7 +362,7 @@
 		<dependency>
 			<groupId>org.xerial.snappy</groupId>
 			<artifactId>snappy-java</artifactId>
-			<version>1.1.4</version>
+			<version>1.1.10.1</version>
 		</dependency>
 		<dependency>
 			<artifactId>httpcore</artifactId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.xerial.snappy:snappy-java 1.1.4
- [CVE-2023-34454](https://www.oscs1024.com/hd/CVE-2023-34454)


### What did I do？
Upgrade org.xerial.snappy:snappy-java from 1.1.4 to 1.1.10.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS