### PR TITLE
fix(sec): upgrade org.apache.calcite:calcite-core to 1.32.0

### DIFF
--- a/chunjun-ddl/pom.xml
+++ b/chunjun-ddl/pom.xml
@@ -72,7 +72,7 @@
 			<dependency>
 				<groupId>org.apache.calcite</groupId>
 				<artifactId>calcite-core</artifactId>
-				<version>1.26.0</version>
+				<version>1.32.0</version>
 				<exclusions>
 					<exclusion>
 						<groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.calcite:calcite-core 1.26.0
- [CVE-2022-39135](https://www.oscs1024.com/hd/CVE-2022-39135)


### What did I do？
Upgrade org.apache.calcite:calcite-core from 1.26.0 to 1.32.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS