### PR TITLE
[hotfix-#1745][connector][hdfs][hive] Data loss occurs when multiple tasks write to the same hdfs (or hive) data source

### DIFF
--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/sink/BaseHdfsOutputFormat.java
@@ -131,7 +131,21 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
 
     @Override
     protected void deleteTmpDataDir() {
-        deleteDirectory(tmpPath);
+        try {
+            Path dir = new Path(outputFilePath);
+            if (fs == null) {
+                openSource();
+            }
+            FileStatus[] fileStatuses =
+                    fs.listStatus(dir, path -> path.getName().startsWith(TMP_DIR_NAME));
+            for (FileStatus fileStatus : fileStatuses) {
+                if (fileStatus.isDirectory()) {
+                    deleteDirectory(fileStatus.getPath().toString());
+                }
+            }
+        } catch (IOException e) {
+            throw new ChunJunRuntimeException("cannot delete tmpDir: ", e);
+        }
     }
 
     @Override

--- a/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/table/HdfsDynamicTableFactory.java
+++ b/chunjun-connectors/chunjun-connector-hdfs/src/main/java/com/dtstack/chunjun/connector/hdfs/table/HdfsDynamicTableFactory.java
@@ -135,6 +135,7 @@ public class HdfsDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         hdfsConfig.setEncoding(config.get(BaseFileOptions.ENCODING));
         hdfsConfig.setMaxFileSize(config.get(BaseFileOptions.MAX_FILE_SIZE));
         hdfsConfig.setNextCheckRows(config.get(BaseFileOptions.NEXT_CHECK_ROWS));
+        hdfsConfig.setJobTimeStamp(config.get(BaseFileOptions.JOB_TIMESTAMP));
 
         hdfsConfig.setDefaultFS(config.get(HdfsOptions.DEFAULT_FS));
         hdfsConfig.setFileType(config.get(HdfsOptions.FILE_TYPE));

--- a/chunjun-connectors/chunjun-connector-hive/src/main/java/com/dtstack/chunjun/connector/hive/table/HiveDynamicTableFactory.java
+++ b/chunjun-connectors/chunjun-connector-hive/src/main/java/com/dtstack/chunjun/connector/hive/table/HiveDynamicTableFactory.java
@@ -228,6 +228,7 @@ public class HiveDynamicTableFactory implements DynamicTableSinkFactory, Dynamic
         hiveConf.setEncoding(config.get(BaseFileOptions.ENCODING));
         hiveConf.setMaxFileSize(config.get(BaseFileOptions.MAX_FILE_SIZE));
         hiveConf.setNextCheckRows(config.get(BaseFileOptions.NEXT_CHECK_ROWS));
+        hiveConf.setJobTimeStamp(config.get(BaseFileOptions.JOB_TIMESTAMP));
 
         hiveConf.setDefaultFS(config.get(HdfsOptions.DEFAULT_FS));
         hiveConf.setFileType(config.get(HdfsOptions.FILE_TYPE));

--- a/chunjun-connectors/chunjun-connector-hive3/src/main/java/com/dtstack/chunjun/connector/hive3/sink/BaseHdfsOutputFormat.java
+++ b/chunjun-connectors/chunjun-connector-hive3/src/main/java/com/dtstack/chunjun/connector/hive3/sink/BaseHdfsOutputFormat.java
@@ -107,7 +107,21 @@ public abstract class BaseHdfsOutputFormat extends BaseFileOutputFormat {
 
     @Override
     protected void deleteTmpDataDir() {
-        deleteDirectory(tmpPath);
+        try {
+            Path dir = new Path(outputFilePath);
+            if (fs == null) {
+                openSource();
+            }
+            FileStatus[] fileStatuses =
+                    fs.listStatus(dir, path -> path.getName().startsWith(TMP_DIR_NAME));
+            for (FileStatus fileStatus : fileStatuses) {
+                if (fileStatus.isDirectory()) {
+                    deleteDirectory(fileStatus.getPath().toString());
+                }
+            }
+        } catch (IOException e) {
+            throw new ChunJunRuntimeException("cannot delete tmpDir: ", e);
+        }
     }
 
     @Override

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/config/BaseFileConfig.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/config/BaseFileConfig.java
@@ -50,4 +50,6 @@ public class BaseFileConfig extends CommonConfig {
     private long nextCheckRows = 5000;
 
     private String suffix;
+
+    private String jobTimeStamp = "";
 }

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/sink/format/BaseFileOutputFormat.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/sink/format/BaseFileOutputFormat.java
@@ -107,7 +107,12 @@ public abstract class BaseFileOutputFormat extends BaseRichOutputFormat {
         } else {
             outputFilePath = baseFileConfig.getPath();
         }
-        tmpPath = outputFilePath + File.separatorChar + TMP_DIR_NAME;
+        tmpPath =
+                outputFilePath
+                        + File.separatorChar
+                        + TMP_DIR_NAME
+                        + baseFileConfig.getJobTimeStamp();
+        log.info("initVariableFields get tmpPath: {}", tmpPath);
         nextNumForCheckDataSize = baseFileConfig.getNextCheckRows();
         openSource();
     }

--- a/chunjun-core/src/main/java/com/dtstack/chunjun/table/options/BaseFileOptions.java
+++ b/chunjun-core/src/main/java/com/dtstack/chunjun/table/options/BaseFileOptions.java
@@ -62,4 +62,11 @@ public class BaseFileOptions {
                     .longType()
                     .defaultValue(5000L)
                     .withDescription("The number of data written in the next file size check");
+
+    public static final ConfigOption<String> JOB_TIMESTAMP =
+            ConfigOptions.key("properties.job-timestamp")
+                    .stringType()
+                    .defaultValue(String.valueOf(System.currentTimeMillis()))
+                    .withDescription(
+                            "To solve the problem of file loss caused by multiple tasks writing to the same output source at the same time");
 }


### PR DESCRIPTION
…tasks write to the same hdfs (or hive) data source

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
