### PR TITLE
[Bug][chunjun-connectors] jdbc's properties not work where jdbc's reader has set properties

### DIFF
--- a/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcSourceFactory.java
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/src/main/java/com/dtstack/chunjun/connector/jdbc/source/JdbcSourceFactory.java
@@ -89,7 +89,7 @@ public abstract class JdbcSourceFactory extends SourceFactory {
         if (StringUtils.isBlank(jdbcConfig.getIncreColumn())) jdbcConfig.setPolling(false);
         jdbcConfig.setColumn(syncConfig.getReader().getFieldList());
 
-        Properties properties = syncConfig.getWriter().getProperties("properties", null);
+        Properties properties = syncConfig.getReader().getProperties("properties", null);
         jdbcConfig.setProperties(properties);
 
         setDefaultSplitStrategy(jdbcConfig);

--- a/chunjun-core/src/test/java/com/dtstack/chunjun/config/BaseFileConfigTest.java
+++ b/chunjun-core/src/test/java/com/dtstack/chunjun/config/BaseFileConfigTest.java
@@ -39,7 +39,7 @@ public class BaseFileConfigTest {
         baseFileConf.setNextCheckRows(5000L);
 
         String expected =
-                "BaseFileConfig(fromLine=1, path=path, fileName=fileName, writeMode=writeMode, compress=compress, encoding=UTF-8, maxFileSize=1024, nextCheckRows=5000, suffix=null)";
+                "BaseFileConfig(fromLine=1, path=path, fileName=fileName, writeMode=writeMode, compress=compress, encoding=UTF-8, maxFileSize=1024, nextCheckRows=5000, suffix=null, jobIdentifier=)";
 
         assertEquals(expected, baseFileConf.toString());
     }


### PR DESCRIPTION
…der has set properties

<!--
*Thank you very much for contributing to ChunJun. We are happy that you want to help us improve ChunJun.*
-->

## Purpose of this pull request
<!-- Describe the purpose of this pull request. For example: This is fix the typo of code.-->

## Which issue you fix
Fixes # (issue).

## Checklist:

- [ ] I have executed the **'mvn spotless:apply'** command to format my code.
- [ ] I have a meaningful commit message (including the issue id, **the template of commit message is '[label-type-#issue-id][fixed-module] a meaningful commit message.'**)
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have checked my code and corrected any misspellings.
- [ ] My commit is only one. (If there are multiple commits, you can use 'git squash' to compress multiple commits into one.)
